### PR TITLE
Remove package data and fix bug in proper motion correction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 mp_get_agasc_bug.png
 miniagasc.h5
-agasc/ra_dec.npy
+ra_dec.npy
 agasc1p6.h5
 doc/_*
 build
+data/
+dist/
+MANIFEST
+parsetab.py

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,7 @@ doc:
 install_doc:
 	mkdir -p $(INSTALL_DOC)
 	rsync --archive --times $(DOC)   $(INSTALL_DOC)/
+
+install_data:
+	mkdir -p $(INSTALL_DATA)
+	rsync --archive --size-only data/agasc/ $(INSTALL_DATA)/

--- a/agasc/__init__.py
+++ b/agasc/__init__.py
@@ -1,1 +1,2 @@
 from .agasc import *
+from .version import version as __version__

--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -80,7 +80,7 @@ def add_pmcorr_columns(stars, date):
     # Compute the multiplicative factor to convert from the AGASC proper motion
     # field to degrees.  The AGASC PM is specified in milliarcsecs / year, so this
     # is dyear * (degrees / milliarcsec)
-    agasc_equinox = DateTime('2000:001:00:00:00.000')
+    agasc_equinox = DateTime(stars['EPOCH'], format='frac_year')
     dyear = (DateTime(date) - agasc_equinox) / 365.25
     pm_to_degrees = dyear / (3600. * 1000.)
 

--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -4,10 +4,13 @@ import numpy as np
 import numexpr
 import tables
 
+from ska_path import ska_path
 from Chandra.Time import DateTime
 from astropy.table import Table, Column
 
 __all__ = ['sphere_dist', 'get_agasc_cone', 'get_star']
+
+DATA_ROOT = ska_path('data', 'agasc')
 
 
 class IdNotFound(LookupError):
@@ -38,7 +41,7 @@ class RaDec(object):
         # Read the file of RA and DEC values (sorted on DEC):
         #  dec: DEC values
         #  ra: RA values
-        radecs = np.load(os.path.join(os.path.dirname(__file__), 'ra_dec.npy'))
+        radecs = np.load(os.path.join(DATA_ROOT, 'ra_dec.npy'))
 
         # Now copy to separate ndarrays for memory efficiency
         return radecs['ra'].copy(), radecs['dec'].copy()
@@ -99,7 +102,7 @@ def get_agasc_cone(ra, dec, radius=1.5, date=None, agasc_file=None):
     :returns: astropy Table of AGASC entries
     """
     if agasc_file is None:
-        agasc_file = os.path.join('/', 'proj', 'sot', 'ska', 'data', 'agasc', 'miniagasc.h5')
+        agasc_file = os.path.join(DATA_ROOT, 'miniagasc.h5')
 
     idx0, idx1 = np.searchsorted(RA_DECS.dec, [dec - radius, dec + radius])
 
@@ -167,7 +170,7 @@ def get_star(id, agasc_file=None):
     """
 
     if agasc_file is None:
-        agasc_file = os.path.join('/', 'proj', 'sot', 'ska', 'data', 'agasc', 'miniagasc.h5')
+        agasc_file = os.path.join(DATA_ROOT, 'miniagasc.h5')
 
     h5 = tables.openFile(agasc_file)
     tbl = h5.root.data

--- a/agasc/version.py
+++ b/agasc/version.py
@@ -8,7 +8,7 @@ NOTE: this code copied from astropy.version and simplified.  Any license
 restrictions therein are applicable.
 """
 
-version = '0.3'
+version = '0.3.1'
 
 _versplit = version.replace('dev', '').split('.')
 major = int(_versplit[0])

--- a/agasc/version.py
+++ b/agasc/version.py
@@ -8,7 +8,7 @@ NOTE: this code copied from astropy.version and simplified.  Any license
 restrictions therein are applicable.
 """
 
-version = '0.2'
+version = '0.3'
 
 _versplit = version.replace('dev', '').split('.')
 major = int(_versplit[0])

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,4 @@ setup(name='agasc',
       author_email='taldcroft@head.cfa.harvard.edu',
       url='http://www.python.org/',
       packages=['agasc'],
-      package_data={'agasc': ['ra_dec.npy']},
       )

--- a/test_agasc.py
+++ b/test_agasc.py
@@ -15,7 +15,8 @@ different results when the faint limit filtering is applied.
 
 Comprehensive test (takes a while):
 >>> import test_agasc
->>> test_agasc.test_agasc(nsample=100)
+>>> test_agasc.test_agasc(nsample=100, agasc_file='miniagasc.h5') # local miniagasc
+>>> test_agasc.test_agasc(nsample=100) # installed  (/proj/sot/ska/data/agasc/miniagasc.h5)
 """
 
 
@@ -103,7 +104,7 @@ def mp_get_agasc(ra, dec, radius):
     return dat
 
 
-def test_agasc(radius=1.4, nsample=2):
+def test_agasc(radius=1.4, nsample=2, agasc_file=None):
     ras, decs = random_ra_dec(nsample)
     ras = np.hstack([ras, [0., 180., 0.1, 180.]])
     decs = np.hstack([decs, [89.9, -89.9, 0.0, 0.0]])
@@ -111,7 +112,7 @@ def test_agasc(radius=1.4, nsample=2):
     for ra, dec in zip(ras, decs):
         print ra, dec
 
-        stars1 = agasc.get_agasc_cone(ra, dec, radius=radius, agasc_file='miniagasc.h5')
+        stars1 = agasc.get_agasc_cone(ra, dec, radius=radius, agasc_file=agasc_file)
         stars1.sort('AGASC_ID')
 
         stars2 = mp_get_agasc(ra, dec, radius)

--- a/test_get_star.py
+++ b/test_get_star.py
@@ -92,7 +92,7 @@ def mp_get_agascid(agasc_id):
     return dat
 
 
-def test_agasc_id(radius=.2, npointings=50, nstar_limit=50):
+def test_agasc_id(radius=.2, npointings=50, nstar_limit=50, agasc_file=None):
     ras, decs = random_ra_dec(npointings)
     ras = np.hstack([ras, [0., 180., 0.1, 180.]])
     decs = np.hstack([decs, [89.9, -89.9, 0.0, 0.0]])
@@ -101,7 +101,7 @@ def test_agasc_id(radius=.2, npointings=50, nstar_limit=50):
     for ra, dec in zip(ras, decs):
         print ra, dec
 
-        cone_stars = agasc.get_agasc_cone(ra, dec, radius=radius, agasc_file='miniagasc.h5')
+        cone_stars = agasc.get_agasc_cone(ra, dec, radius=radius, agasc_file=agasc_file)
         if len(cone_stars) == 0:
             continue
         cone_stars.sort('AGASC_ID')


### PR DESCRIPTION
This changes where the miniagasc.h5 file is located to better support conda skare.

It also fixes an apparent bug in the proper motion correction where the RA term is not divided by cos(Dec).  As I understand the PM_RA value is in milliarcsec / year, i.e. a normal angular distance.  It looks like the same issue is in Ska-Agasc.

This PR also adds *_PMCORR values to the output of `agasc.get_star()`.

It's not ideal to wrap up these unrelated fixes, but I want the PM fix in conda and I don't see a good reason to not put the conda-driven changes into Ska flight.

@jeanconn 