### PR TITLE
Add a warning filter to ignore numexpr oa_ndim dep warnings

### DIFF
--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -8,6 +8,12 @@ from ska_path import ska_path
 from Chandra.Time import DateTime
 from astropy.table import Table, Column
 
+import warnings
+warnings.filterwarnings(
+    'ignore',
+    message="using `oa_ndim == 0` when `op_axes` is NULL is deprecated.*",
+    category=DeprecationWarning)
+
 __all__ = ['sphere_dist', 'get_agasc_cone', 'get_star']
 
 DATA_ROOT = ska_path('data', 'agasc')


### PR DESCRIPTION
Add a warning filter to ignore numexpr oa_ndim dep warnings like:

DeprecationWarning: using `oa_ndim == 0` when `op_axes` is NULL is deprecated. Use `oa_ndim == -1` or the MultiNew iterator for NumPy <1.8 compatibility

These warnings seem to be thrown in agasc on tables.readWhere on Py2.


