### PR TITLE
Only calculate times for proper motion for stars that need it

### DIFF
--- a/agasc/__init__.py
+++ b/agasc/__init__.py
@@ -1,6 +1,6 @@
 from .agasc import *
 
-__version__ = '3.5.1'
+__version__ = '3.5.2'
 
 
 def test(*args, **kwargs):

--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -99,12 +99,14 @@ def add_pmcorr_columns(stars, date):
     # The dyear for proper motion is only relevant for stars that have defined proper motion
     # so set to zero for all stars by default
     dyear = np.zeros(len(stars))
+    has_pm = (stars['PM_DEC'] != -9999) | (stars['PM_RA'] != -9999)
     # For most of them, the epoch is fixed at 2000, so we don't need N calls to DateTime to
     # figure that out
-    ok = ((stars['PM_DEC'] != -9999) | (stars['PM_RA'] != -9999)) & (stars['EPOCH'] == 2000.0)
+    epoch_is_2000 = (stars['EPOCH'] == 2000.0)
+    ok = has_pm & epoch_is_2000
     dyear[ok] = (DateTime(date) - DateTime(2000, format='frac_year')) / 365.25
-    # For any other EPOCHs that have a proper motion correction, do them individually
-    ok = ((stars['PM_DEC'] != -9999) | (stars['PM_RA'] != -9999)) & (stars['EPOCH'] != 2000.0)
+    # For stars with proper motion correction but epoch != 2000, calculate individually.
+    ok = has_pm & ~epoch_is_2000
     dyear[ok] = (DateTime(date) - DateTime(stars[ok]['EPOCH'], format='frac_year')) / 365.25
     pm_to_degrees = dyear / (3600. * 1000.)
 

--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -107,7 +107,7 @@ def add_pmcorr_columns(stars, date):
     dyear[ok] = (DateTime(date) - DateTime(2000, format='frac_year')) / 365.25
     # For stars with proper motion correction but epoch != 2000, calculate individually.
     ok = has_pm & ~epoch_is_2000
-    dyear[ok] = (DateTime(date) - DateTime(stars[ok]['EPOCH'], format='frac_year')) / 365.25
+    dyear[ok] = (DateTime(date) - DateTime(stars['EPOCH'][ok], format='frac_year')) / 365.25
     pm_to_degrees = dyear / (3600. * 1000.)
 
     dec_pmcorr = np.where(stars['PM_DEC'] != -9999,

--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -96,7 +96,7 @@ def add_pmcorr_columns(stars, date):
     # field to degrees.  The AGASC PM is specified in milliarcsecs / year, so this
     # is dyear * (degrees / milliarcsec)
 
-    # The dyear for proper motion is only relevent for stars that have not -9999 proper motion
+    # The dyear for proper motion is only relevant for stars that have defined proper motion
     # so set to zero for all stars by default
     dyear = np.zeros(len(stars))
     # For most of them, the epoch is fixed at 2000, so we don't need N calls to DateTime to

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -26,7 +26,6 @@ import re
 
 import numpy as np
 import Ska.Shell
-from Chandra.Time import DateTime
 from astropy.io import ascii
 import pytest
 
@@ -213,24 +212,18 @@ def test_proper_motion():
     assert len(stars) == 0
 
 
-@pytest.mark.parametrize("agasc_id,label",
-                         [(1180612288, "high proper motion, epoch 2000"),
-                          (198451217, "epoch 1982 star"),
-                          (501219465, "epoch 1984 star")])
-def test_add_pmcorr_is_consistent(agasc_id, label):
+@pytest.mark.parametrize(
+    "agasc_id,date,ra_pmcorr,dec_pmcorr,label",
+    [(1180612288, '2020:001', 219.86433151831795, -60.831868007221289, "high proper motion, epoch 2000"),
+     (198451217, '2020:001', 247.89220668106938, 19.276605555555559, "epoch 1982 star"),
+     (501219465, '2020:001', 166.99897608782592, 52.82208000152103, "epoch 1984 star")])
+def test_add_pmcorr_is_consistent(agasc_id, date, ra_pmcorr, dec_pmcorr, label):
     """
-    Check that the proper-motion corrected position is consistent with the star proper-motion.
-    Do this by calculating the catalog proper motion values from the corrected position.
+    Check that the proper-motion corrected position is consistent reference/regress values.
     """
-    date = '2020:001'
     star = agasc.get_star(agasc_id, date=date)
-    dyear = DateTime(date).frac_year - star['EPOCH']
-    pm_to_degrees = dyear / (3600. * 1000.)
-    pm_dec = (star['DEC_PMCORR'] - star['DEC']) / pm_to_degrees
-    assert np.round(pm_dec) == star['PM_DEC']
-    ra_scale = np.cos(np.radians(star['DEC']))
-    pm_ra = (star['RA_PMCORR'] - star['RA']) * ra_scale / pm_to_degrees
-    assert np.round(pm_ra) == star['PM_RA']
+    assert np.isclose(star['RA_PMCORR'], ra_pmcorr)
+    assert np.isclose(star['DEC_PMCORR'], dec_pmcorr)
 
 
 def mp_get_agascid(agasc_id):

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -26,6 +26,7 @@ import re
 
 import numpy as np
 import Ska.Shell
+from Chandra.Time import DateTime
 from astropy.io import ascii
 import pytest
 
@@ -210,6 +211,26 @@ def test_proper_motion():
     stars = agasc.get_agasc_cone(star['RA_PMCORR'], star['DEC_PMCORR'], radius, date='2017:001',
                                  pm_filter=False)
     assert len(stars) == 0
+
+
+@pytest.mark.parametrize("agasc_id,label",
+                         [(1180612288, "high proper motion, epoch 2000"),
+                          (198451217, "epoch 1982 star"),
+                          (501219465, "epoch 1984 star")])
+def test_add_pmcorr_is_consistent(agasc_id, label):
+    """
+    Check that the proper-motion corrected position is consistent with the star proper-motion.
+    Do this by calculating the catalog proper motion values from the corrected position.
+    """
+    date = '2020:001'
+    star = agasc.get_star(agasc_id, date=date)
+    dyear = DateTime(date).frac_year - star['EPOCH']
+    pm_to_degrees = dyear / (3600. * 1000.)
+    pm_dec = (star['DEC_PMCORR'] - star['DEC']) / pm_to_degrees
+    assert np.round(pm_dec) == star['PM_DEC']
+    ra_scale = np.cos(np.radians(star['DEC']))
+    pm_ra = (star['RA_PMCORR'] - star['RA']) * ra_scale / pm_to_degrees
+    assert np.round(pm_ra) == star['PM_RA']
 
 
 def mp_get_agascid(agasc_id):

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -222,8 +222,8 @@ def test_add_pmcorr_is_consistent(agasc_id, date, ra_pmcorr, dec_pmcorr, label):
     Check that the proper-motion corrected position is consistent reference/regress values.
     """
     star = agasc.get_star(agasc_id, date=date)
-    assert np.isclose(star['RA_PMCORR'], ra_pmcorr)
-    assert np.isclose(star['DEC_PMCORR'], dec_pmcorr)
+    assert np.isclose(star['RA_PMCORR'], ra_pmcorr, rtol=0, atol=1e-5)
+    assert np.isclose(star['DEC_PMCORR'], dec_pmcorr, rtol=0, atol=1e-5)
 
 
 def mp_get_agascid(agasc_id):


### PR DESCRIPTION
Only calculate times for proper motion for stars that need it.

This reduces the number of DateTime fracyear conversions from thousands to, basically 1, for most fields.