### PR TITLE
Use astype to avoid np.float16 ras, decs causing segfault

### DIFF
--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -80,10 +80,10 @@ def sphere_dist(ra1, dec1, ra2, dec2):
     :returns: angular separation distance (deg)
     """
 
-    ra1 = np.radians(ra1)
-    ra2 = np.radians(ra2)
-    dec1 = np.radians(dec1)
-    dec2 = np.radians(dec2)
+    ra1 = np.radians(ra1).astype(np.float64)
+    ra2 = np.radians(ra2).astype(np.float64)
+    dec1 = np.radians(dec1).astype(np.float64)
+    dec2 = np.radians(dec2).astype(np.float64)
 
     numerator = numexpr.evaluate('sin((dec2 - dec1) / 2) ** 2 + '
                                  'cos(dec1) * cos(dec2) * sin((ra2 - ra1) / 2) ** 2')

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -187,6 +187,11 @@ def test_basic():
     assert np.allclose(stars['MAG_ACA'][:5], mags)
 
 
+def test_float16():
+    stars = agasc.get_agasc_cone(np.float16(219.90279), np.float16(-60.83358), .015)
+    assert stars['AGASC_ID'][0] == 1180612176
+
+
 def test_proper_motion():
     """
     Test that the filtering in get_agasc_cone correctly expands the initial


### PR DESCRIPTION
Use astype to avoid np.float16 ras, decs causing segfault #20
