### PR TITLE
Changes to create_mini_agasc_h5 for arbitrary AGASC version

### DIFF
--- a/create_mini_agasc_h5.py
+++ b/create_mini_agasc_h5.py
@@ -1,16 +1,27 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import argparse
+import re
+
 import numpy as np
 import tables
 import Ska.Table
 from astropy.table import Table
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--version',
+                    default='1p7',
+                    help='Version (e.g. 1p6 or 1p7, default=1p7')
+args = parser.parse_args()
 
-example_file = '/data/agasc1p6/agasc/n0000/0001.fit'
+num_version = re.sub(r'p', '.', args.version)
+
+example_file = '/proj/sot/ska/data/agasc{}/agasc/n0000/0001.fit'.format(args.version)
 dtype = Ska.Table.read_fits_table(example_file).dtype
 table_desc, bo = tables.descr_from_dtype(dtype)
 
-print 'Reading full agasc and selecting useable stars'
-h5 = tables.openFile('agasc1p6.h5', mode='r')
+filename = 'agasc{}.h5'.format(args.version)
+print 'Reading full AGASC {} and selecting useable stars'.format(filename)
+h5 = tables.openFile(filename, mode='r')
 tbl = h5.getNode("/", 'data')
 idxs = tbl.getWhereList("(MAG_ACA - (3.0 * MAG_ACA_ERR / 100.0)) < 11.5")
 stars = tbl.readCoordinates(idxs)
@@ -20,18 +31,12 @@ print 'Sorting on Dec and re-ordering'
 idx = np.argsort(stars['DEC'])
 stars = stars.take(idx)
 
-ra = np.array(stars['RA'], dtype='f8')
-dec = np.array(stars['DEC'], dtype='f8')
-
-print 'Saving lightweight index ra_dec.npy'
-out = Table([ra, dec], names=('ra', 'dec'))
-np.save('ra_dec.npy', out)
-
 print 'Creating miniagasc.h5 file'
-minih5 = tables.openFile('miniagasc.h5', mode='w')
+filename = 'miniagasc_{}.h5'.format(args.version)
+minih5 = tables.openFile(filename, mode='w')
 minitbl = minih5.createTable('/', 'data', table_desc,
-                             title='AGASC 1.6')
-print 'Appending stars to miniagasc.h5 file'
+                             title='AGASC {}'.format(num_version))
+print 'Appending stars to {} file'.format(filename)
 minitbl.append(stars)
 minitbl.flush()
 


### PR DESCRIPTION
Houston, we have a problem...  I decided that I wanted the 1.7 miniagasc now to start using in proseco development, so went ahead with the few patches to make this happen.  It worked for 1p6 but failed for 1p7.   In my work `agasc1p7.h5` is a link to `/proj/sot/ska/data/agasc/agasc1p7.h5`.  

It looks like there is something really different.  @malgosias - please investigate! 

```
ska-kadi$ python create_mini_agasc_h5.py --version=1p6
Reading full AGASC agasc1p6.h5 and selecting useable stars
Sorting on Dec and re-ordering
Creating miniagasc.h5 file
Appending stars to miniagasc_1p6.h5 file
Creating indexes in miniagasc.h5 file
Flush and close miniagasc.h5 file

ska-kadi$ python create_mini_agasc_h5.py --version=1p7
Reading full agasc agasc1p7.h5 and selecting useable stars
Traceback (most recent call last):
  File "create_mini_agasc_h5.py", line 24, in <module>
    h5 = tables.openFile(filename, mode='r')
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/tables/file.py", line 258, in openFile
    return File(filename, mode, title, rootUEP, filters, **kwargs)
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/tables/file.py", line 533, in __init__
    self._g_new(filename, mode, **params)
  File "hdf5Extension.pyx", line 281, in tables.hdf5Extension.File._g_new (tables/hdf5Extension.c:2180)
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/tables/utils.py", line 143, in checkFileAccess
    raise IOError("``%s`` does not exist" % (filename,))
IOError: ``agasc1p7.h5`` does not exist
ska-kadi$ ln -s /proj/sot/ska/data/agasc/agasc1p7.h5 ./
ska-kadi$ python create_mini_agasc_h5.py --version=1p7
Reading full agasc agasc1p7.h5 and selecting useable stars
Sorting on Dec and re-ordering
Creating miniagasc.h5 file
Appending stars to miniagasc_1p7.h5 file
Traceback (most recent call last):
  File "create_mini_agasc_h5.py", line 40, in <module>
    minitbl.append(stars)
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-6/lib/python2.7/site-packages/tables/table.py", line 2076, in append
    "rows parameter cannot be converted into a recarray object compliant with table '%s'. The error was: <%s>" % (str(self), exc)
ValueError: rows parameter cannot be converted into a recarray object compliant with table '/data (Table(0,)) 'AGASC 1.7''. The error was: <new type not compatible with array.>
Closing remaining open files: miniagasc_1p7.h5... done
```
