### PR TITLE
Agasc1p7

### DIFF
--- a/create_agasc_h5.py
+++ b/create_agasc_h5.py
@@ -7,19 +7,19 @@ from glob import glob
 import Ska.Numpy
 
 
-example_file = '/data/agasc1p6/agasc/n0000/0001.fit'
+example_file = '/proj/sot/ska/data/agasc1p7/agasc/n0000/0001.fit'
 dtype = Ska.Table.read_fits_table(example_file).dtype
 table_desc, bo = tables.descr_from_dtype(dtype)
 #filters = tables.Filters(complevel=5, complib='zlib')
-h5 = tables.openFile('agasc1p6.h5', mode='w')
+h5 = tables.openFile('agasc1p7.h5', mode='w')
 tbl = h5.createTable('/', 'data', table_desc,
-                     title='AGASC 1.6')
+                     title='AGASC 1.7')
 tbl.flush()
 h5.flush()
 h5.close()
 
-AGASC_DIR = '/data/agasc1p6/agasc'
-h5 = tables.openFile('agasc1p6.h5', mode='a')
+AGASC_DIR = '/proj/sot/ska/data/agasc1p7/agasc'
+h5 = tables.openFile('agasc1p7.h5', mode='a')
 tbl = h5.getNode('/', 'data')
 for chunk in glob(os.path.join(AGASC_DIR, "?????")):
     for file in glob(os.path.join(chunk, "????.fit")):
@@ -28,5 +28,11 @@ for chunk in glob(os.path.join(AGASC_DIR, "?????")):
         tbl.append(stars)
         tbl.flush()
         h5.flush()
+
+print 'Creating indexes in agasc1p7.h5 file'
+tbl.cols.RA.createCSIndex()
+tbl.cols.DEC.createCSIndex()
+tbl.cols.AGASC_ID.createCSIndex()
+
 h5.flush()
 h5.close()

--- a/create_mini_agasc_h5.py
+++ b/create_mini_agasc_h5.py
@@ -5,12 +5,12 @@ import Ska.Table
 from astropy.table import Table
 
 
-example_file = '/data/agasc1p6/agasc/n0000/0001.fit'
+example_file = '/proj/sot/ska/data/agasc1p7/agasc/n0000/0001.fit'
 dtype = Ska.Table.read_fits_table(example_file).dtype
 table_desc, bo = tables.descr_from_dtype(dtype)
 
 print 'Reading full agasc and selecting useable stars'
-h5 = tables.openFile('agasc1p6.h5', mode='r')
+h5 = tables.openFile('agasc1p7.h5', mode='r')
 tbl = h5.getNode("/", 'data')
 idxs = tbl.getWhereList("(MAG_ACA - (3.0 * MAG_ACA_ERR / 100.0)) < 11.5")
 stars = tbl.readCoordinates(idxs)
@@ -30,7 +30,7 @@ np.save('ra_dec.npy', out)
 print 'Creating miniagasc.h5 file'
 minih5 = tables.openFile('miniagasc.h5', mode='w')
 minitbl = minih5.createTable('/', 'data', table_desc,
-                             title='AGASC 1.6')
+                             title='AGASC 1.7')
 print 'Appending stars to miniagasc.h5 file'
 minitbl.append(stars)
 minitbl.flush()

--- a/test_agasc1p7.py
+++ b/test_agasc1p7.py
@@ -59,10 +59,15 @@ for col in h5_fits.dtype.names:
     c_jupyter = h5_jupyter[col]
     c_1p6 = h5_1p6[col]
 
-    # All values for all columns are identical between the V1.7 h5 files
-    # from fits files and from jupyter notebook
+    # All values for all columns, except the RSV1 column, are identical between
+    # the V1.7 h5 files from fits files and from jupyter notebook
 
-    assert np.all(c_fits == c_jupyter)
+    if col == 'RSV1':
+        # fits have RSV1 overwritten with -9999 for stars that did not change
+        assert np.all(c_fits[ok] == -9999)
+        assert np.all(c_fits[~ok] != -9999)
+    else:
+        assert np.all(c_fits == c_jupyter)
 
     test_cols = ('RSV1', 'RSV2', 'RSV3', 'MAG_ACA', 'MAG_ACA_ERR')
 
@@ -70,10 +75,13 @@ for col in h5_fits.dtype.names:
         # We see only expected differences in MAG_ACA, MAG_ACA_ERR, RSV1-3
         # between V1.7 and V1.6
 
-        assert np.all(c_fits[ok] == c_1p6[ok])
+        assert np.all(c_jupyter[ok] == c_1p6[ok])
+        if col != 'RSV1':
+            assert np.all(c_fits[ok] == c_1p6[ok])
 
         if col != 'MAG_ACA_ERR':
-            # because ~1% of stars that changed have unchanged MAG_ACA_ERR
+            # because ~1% of stars have MAG_ACA_ERR change that is too small to
+            # be reflected in the new h5 file where MAG_ACA_ERR is a small int
             assert np.all(c_fits[~ok] != c_1p6[~ok])
     else:
         # All values for all columns except MAG_ACA, MAG_ACA_ERR, RSV1-3

--- a/test_agasc1p7.py
+++ b/test_agasc1p7.py
@@ -1,47 +1,113 @@
 
+"""
+Test script for the AGASC V1.7.
+
+Files required for the test:
+    1. Input h5 file (agasc1p7_from_jupyter.h5) created from jupyter notebook,
+       agasc_apass_recalibration.ipynb in /proj/sot/ska/www/ASPECT/ipynb
+    2. AGASC V1.6 and V1.7 fits files.
+    3. New h5 file (agasc1p7_from_fits.h5) created from fits files using the
+       create_agasc_h5.py script.
+    4. AGASC V1.6 h5 file.
+
+The test consists of the following steps:
+    1. Confirm that all the fields in all the columns in agasc1p7_from_fits.h5
+       file match values in the input agasc1p7_jupter.h5 file.
+    2. Confirm that all the fields in all columns other than MAG_ACA,
+       MAG_ACA_ERR, RSV1-3 in agasc1p7_from_fits.h5 file match values
+       in V1.6 h5 file.
+    3. Confirm that we see expected differences between agasc1p7_from_fits.h5
+       file relative to the V1.6 h5 file (MAG_ACA, MAG_ACA_ERR, RSV1-3 cols)
+    4. Verify that comment changes in the fits files are as expected, diff
+       of the comments cards for all fits files.
+"""
 import numpy as np
 import tables
+import tables3_api
+from glob import glob
+import os
+from astropy.io import fits
+import difflib
+import re
 
-h5 = tables.openFile('agasc1p7.h5', mode='r')
-h5inp = tables.openFile('/proj/sot/ska/data/agasc/agasc1p7.h5', mode='r')
-h51p6 = tables.openFile('/proj/sot/ska/data/agasc/agasc1p6.h5', mode='r')
 
-assert np.all(h5.root.data.colnames == h51p6.root.data.colnames)
-assert np.all(h5.root.data.colnames == h5inp.root.data.colnames)
+difflines = """!               THE AXAF GUIDE and ACQUISITION STAR CATALOG V1.6
+! the AXAF Guide and Acquisition Star Catalog (AGASC) version 1.6
+! V1.6 changes values for MAG_ACA and MAG_ACA_ERR only.  See
+! http://asc.harvard.edu/mta/ASPECT/agasc1p6cal for details
+!               THE AXAF GUIDE and ACQUISITION STAR CATALOG V1.7
+! the AXAF Guide and Acquisition Star Catalog (AGASC) version 1.7
+! V1.7 changes values for MAG_ACA, MAG_ACA_ERR, RSV1, RSV2 and RSV3""".split('\n')
 
-colnames = h5.root.data.colnames
+h5_fits = tables.openFile('agasc1p7_from_fits.h5', mode='r')
+h5_jupyter = tables.openFile('agasc1p7_from_jupyter.h5', mode='r')
+h5_1p6 = tables.openFile('/proj/sot/ska/data/agasc/agasc1p6.h5', mode='r')
 
-# stars with no changes
-ok = h5.root.data.col('RSV3') == 0
+assert np.all(h5_fits.root.data.colnames == h5_1p6.root.data.colnames)
+assert np.all(h5_fits.root.data.colnames == h5_jupyter.root.data.colnames)
 
-agasc_ids = h5.root.data.col('AGASC_ID')
-agasc_ids2 = h5inp.root.data.col('AGASC_ID')
-agasc_ids3 = h51p6.root.data.col('AGASC_ID')
+colnames = h5_fits.root.data.colnames
 
-idx = np.arange(len(agasc_ids))
+ok = h5_fits.root.data.col('RSV3') == 0  # stars with no changes
 
-id_map2 = dict(zip(agasc_ids2, idx))
-id_map3 = dict(zip(agasc_ids3, idx))
+agasc_ids_fits = h5_fits.root.data.col('AGASC_ID')
+agasc_ids_jupyter = h5_jupyter.root.data.col('AGASC_ID')
+agasc_ids_1p6 = h5_1p6.root.data.col('AGASC_ID')
 
-h5inp_id_map = [id_map2[agasc_id] for agasc_id in agasc_ids]
-h51p6_id_map = [id_map3[agasc_id] for agasc_id in agasc_ids]
+idx = np.arange(len(agasc_ids_fits))
+
+id_map_jupyter = dict(zip(agasc_ids_jupyter, idx))
+id_map_1p6 = dict(zip(agasc_ids_1p6, idx))
+
+h5_jupyter_id_map = [id_map_jupyter[agasc_id] for agasc_id in agasc_ids_fits]
+h5_1p6_id_map = [id_map_1p6[agasc_id] for agasc_id in agasc_ids_fits]
 
 for col in colnames:
-    c1 = h5.root.data.col(col)
+    print "Processing column %s" % col
 
-    c2 = h5inp.root.data.col(col)
-    c2 = c2[h5inp_id_map]
+    c_fits = h5_fits.root.data.col(col)
 
-    c3 = h51p6.root.data.col(col)
-    c3 = c3[h51p6_id_map]
+    c_jupyter = h5_jupyter.root.data.col(col)
+    c_jupyter = c_jupyter[h5_jupyter_id_map]
 
-    assert np.all(c1 == c2)
+    c_1p6 = h5_1p6.root.data.col(col)
+    c_1p6 = c_1p6[h5_1p6_id_map]
+
+    # All values for all columns are identical between the V1.7 h5 files
+    # from fits files and from jupyter notebook
+    assert np.all(c_fits == c_jupyter)
 
     if col not in ['RSV1', 'RSV2', 'RSV3', 'MAG_ACA', 'MAG_ACA_ERR']:
-        assert np.all(c1 == c3)
+        # All values for all columns except MAG_ACA, MAG_ACA_ERR, RSV1-3
+        # are identical between V1.7 and V1.6
+        assert np.all(c_fits == c_1p6)
     else:
-        assert np.all(c1[ok] == c3[ok])
+        # We see only expected differences in MAG_ACA, MAG_ACA_ERR, RSV1-3
+        # between V1.7 and V1.6
+        assert np.all(c_fits[ok] == c_1p6[ok])
+        assert np.all(c_fits[~ok] != c_1p6[~ok])
 
-h5.close()
-h5inp.close()
-h51p6.close()
+h5_fits.close()
+h5_jupyter.close()
+h5_1p6.close()
+
+# Diff of the comment cards for all V1.6 and V1.7 fits files
+AGASC_DIR_1p6 = '/proj/sot/ska/data/agasc1p6/agasc'
+for chunk in glob(os.path.join(AGASC_DIR_1p6, "?????")):
+    print "processing fits files in chunk %s" % chunk
+    for file_1p6 in glob(os.path.join(chunk, "????.fit")):
+        file_1p7 = file_1p6.replace('agasc1p6', 'agasc1p7')
+
+        hdu_1p6 = fits.open(file_1p6)
+        hdu_1p7 = fits.open(file_1p7)
+        comment_1p6 = hdu_1p6[0].header['COMMENT']
+        comment_1p7 = hdu_1p7[0].header['COMMENT']
+        d = difflib.context_diff(comment_1p6, comment_1p7)
+        dls = [line for line in d]
+        ok = [re.search('1[.pvV][67]', item) is not None for item in dls]
+        ok = np.array(ok, dtype=bool)
+
+        assert np.all(np.array(dls)[ok] == np.array(difflines))
+
+        hdu_1p6.close()
+        hdu_1p7.close()

--- a/test_agasc1p7.py
+++ b/test_agasc1p7.py
@@ -1,0 +1,47 @@
+
+import numpy as np
+import tables
+
+h5 = tables.openFile('agasc1p7.h5', mode='r')
+h5inp = tables.openFile('/proj/sot/ska/data/agasc/agasc1p7.h5', mode='r')
+h51p6 = tables.openFile('/proj/sot/ska/data/agasc/agasc1p6.h5', mode='r')
+
+assert np.all(h5.root.data.colnames == h51p6.root.data.colnames)
+assert np.all(h5.root.data.colnames == h5inp.root.data.colnames)
+
+colnames = h5.root.data.colnames
+
+# stars with no changes
+ok = h5.root.data.col('RSV3') == 0
+
+agasc_ids = h5.root.data.col('AGASC_ID')
+agasc_ids2 = h5inp.root.data.col('AGASC_ID')
+agasc_ids3 = h51p6.root.data.col('AGASC_ID')
+
+idx = np.arange(len(agasc_ids))
+
+id_map2 = dict(zip(agasc_ids2, idx))
+id_map3 = dict(zip(agasc_ids3, idx))
+
+h5inp_id_map = [id_map2[agasc_id] for agasc_id in agasc_ids]
+h51p6_id_map = [id_map3[agasc_id] for agasc_id in agasc_ids]
+
+for col in colnames:
+    c1 = h5.root.data.col(col)
+
+    c2 = h5inp.root.data.col(col)
+    c2 = c2[h5inp_id_map]
+
+    c3 = h51p6.root.data.col(col)
+    c3 = c3[h51p6_id_map]
+
+    assert np.all(c1 == c2)
+
+    if col not in ['RSV1', 'RSV2', 'RSV3', 'MAG_ACA', 'MAG_ACA_ERR']:
+        assert np.all(c1 == c3)
+    else:
+        assert np.all(c1[ok] == c3[ok])
+
+h5.close()
+h5inp.close()
+h51p6.close()


### PR DESCRIPTION
This is a pull request for updated create*.py scripts changed so that they work with AGASC V1.7, and V1.7 test script which:
- confirms that all the fields in all the columns match values in the input agasc1p7.h5 file (new h5 file created from Jean's fits files is in /home/malgosia/git/agasc/agasc1p7.h5, branch agasc1p7)
- confirms that there are no differences between agasc1p7.h5 file and 1.6 file in columns other than new mag_aca, mag_aca_err and rsv 1-3 columns.

These tests fail for one star entry and it is not clear to me why: the AGASC_ID is OK, but RA and DEC are slightly different, there is also a difference in COLOR2 column (and I did not check the remaining columns for this one failing entry).

What is missing is a confirmation that we do see expected differences between agasc1p7.h5 file and 1.6 in new mag_aca, mag_aca_err and rsvd 1-3 columns. But I would like to first understand the origin of this one entry that fails the above tests. Let me know if you can think of any reasons for this.

