### PR TITLE
Call out the miniagasc version (1p6) when testing vs DS AGASC

### DIFF
--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -138,7 +138,7 @@ def test_agasc_conesearch(ra, dec):
     _test_agasc(ra, dec)
 
 
-def _test_agasc(ra, dec, radius=1.4, agasc_file=None):
+def _test_agasc(ra, dec, radius=1.4, agasc_file='/proj/sot/ska/data/agasc/miniagasc_1p6.h5'):
     stars1 = agasc.get_agasc_cone(ra, dec, radius=radius, agasc_file=agasc_file,
                                   date='2000:001')
     stars1.sort('AGASC_ID')
@@ -238,7 +238,7 @@ def mp_get_agascid(agasc_id):
 
 @pytest.mark.skipif('not HAS_KSH')
 @pytest.mark.skipif('ascds_env is None')
-def test_agasc_id(radius=0.2, npointings=2, nstar_limit=5, agasc_file=None):
+def test_agasc_id(radius=0.2, npointings=2, nstar_limit=5, agasc_file='/proj/sot/ska/data/agasc/miniagasc_1p6.h5'):
     ras, decs = random_ra_dec(npointings)
 
     for ra, dec in zip(ras, decs):
@@ -251,7 +251,7 @@ def test_agasc_id(radius=0.2, npointings=2, nstar_limit=5, agasc_file=None):
         cone_stars.sort('AGASC_ID')
         for agasc_id in cone_stars['AGASC_ID'][:nstar_limit]:
             print('  agasc_id =', agasc_id)
-            star1 = agasc.get_star(agasc_id)
+            star1 = agasc.get_star(agasc_id, agasc_file=agasc_file)
             star2 = mp_get_agascid(agasc_id)
             for colname in AGASC_COLNAMES:
                 if star1[colname].dtype.kind == 'f':


### PR DESCRIPTION
DS AGASC is set at 1.6, so use miniagasc 1.6 explicitly for the "vs" testing, done via "mp_get_agasc".  This is just a temporary test fix, and might be fine staying as a PR that just shows what changes were needed to get the tests to pass once miniagasc.h5 was set to the 1p7 version.