### PR TITLE
Include near neighbor stars and exclude rarely used cols from miniagasc

### DIFF
--- a/create_mini_agasc_h5.py
+++ b/create_mini_agasc_h5.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+
 import argparse
 import re
 
@@ -11,21 +12,54 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--version',
                     default='1p7',
                     help='Version (e.g. 1p6 or 1p7, default=1p7')
+parser.add_argument('--include-near-neighbors',
+                    default=True,
+                    action='store_false',
+                    help='Include near neighbor stars')
+parser.add_argument('--exclude-rarely-used-cols',
+                    default=True,
+                    action='store_false',
+                    help='Exclude columns that are rarely used in operations')
 args = parser.parse_args()
 
 num_version = re.sub(r'p', '.', args.version)
 
-example_file = '/proj/sot/ska/data/agasc{}/agasc/n0000/0001.fit'.format(args.version)
-dtype = Ska.Table.read_fits_table(example_file).dtype
-table_desc, bo = tables.descr_from_dtype(dtype)
-
 filename = 'agasc{}.h5'.format(args.version)
 print 'Reading full AGASC {} and selecting useable stars'.format(filename)
-h5 = tables.openFile(filename, mode='r')
-tbl = h5.getNode("/", 'data')
-idxs = tbl.getWhereList("(MAG_ACA - (3.0 * MAG_ACA_ERR / 100.0)) < 11.5")
-stars = tbl.readCoordinates(idxs)
+
+h5 = tables.openFile(filename)
+stars = h5.root.data[:]
 h5.close()
+
+# Filter mags
+ok = stars['MAG_ACA'] - 3.0 * stars['MAG_ACA_ERR'] / 100.0 < 11.5
+
+# Put back near-neighbor stars that got cut by above mag filter. This file
+# is made with create_near_neighbor_ids.py.
+if args.include_near_neighbors:
+    near_file = 'near_neighbor_ids_{}.fits.gz'.format(args.version)
+    near_table = Table.read(near_file, format='fits')
+    near_ids = set(near_table['near_id'])
+    print "Including {} near neighbor stars".format(len(near_ids))
+    for idx, agasc_id in enumerate(stars['AGASC_ID']):
+        if agasc_id in near_ids:
+            ok[idx] = True
+
+# Filter down to miniagasc stars
+print 'Filtering from {} to {} stars'.format(len(stars), np.count_nonzero(ok))
+stars = stars[ok]
+
+if args.exclude_rarely_used_cols:
+    print 'Excluding rarely used columns'
+    excludes = ['PLX', 'PLX_ERR', 'PLX_CATID',
+                'ACQQ1', 'ACQQ2', 'ACQQ3', 'ACQQ4', 'ACQQ5', 'ACQQ6',
+                'XREF_ID1', 'XREF_ID2', 'XREF_ID3', 'XREF_ID4', 'XREF_ID5',
+                'RSV4', 'RSV5', 'RSV6']
+    names = [name for name in stars.dtype.names if name not in excludes]
+    print 'Dtype before excluding:\n', stars.dtype
+    stars = Table([stars[name] for name in names], names=names, copy=False)
+    stars = stars.as_array()
+    print 'Dtype after excluding:\n', stars.dtype
 
 print 'Sorting on Dec and re-ordering'
 idx = np.argsort(stars['DEC'])
@@ -33,6 +67,7 @@ stars = stars.take(idx)
 
 print 'Creating miniagasc.h5 file'
 filename = 'miniagasc_{}.h5'.format(args.version)
+table_desc, bo = tables.descr_from_dtype(stars.dtype)
 minih5 = tables.openFile(filename, mode='w')
 minitbl = minih5.createTable('/', 'data', table_desc,
                              title='AGASC {}'.format(num_version))

--- a/create_near_neighbor_ids.py
+++ b/create_near_neighbor_ids.py
@@ -1,0 +1,51 @@
+# coding: utf-8
+
+"""
+Create a file near_neighbor_ids.fits.gz which contains a single column
+of AGASC IDs corresponding to all stars in AGASC 1.7 that are within
+60 arcsec of a candidate guide or acq star.
+
+This takes a while to run and should be done on a computer with copy
+of AGASC 1.7 on a local (fast) drive.
+
+Usage::
+
+  $ python make_near_neighbor_ids.py
+"""
+import tables
+import os
+from pathlib import Path
+
+import agasc
+from astropy.table import Table
+
+agasc1p7 = str(Path(os.environ['SKA'], 'data', 'agasc', 'agasc1p7.h5'))
+
+h5 = tables.open_file(agasc1p7)
+stars = h5.root.data[:]
+h5.close()
+
+ok = ((stars['CLASS'] == 0) &
+      (stars['MAG_ACA'] < 11.0) &
+      (stars['ASPQ1'] < 50) &  # Less than 2.5 arcsec from nearby star
+      (stars['ASPQ1'] > 0) &
+      (stars['ASPQ2'] == 0)  # Proper motion less than 0.5 arcsec/yr
+      )
+
+# Candidate acq/guide stars with a near neighbor that made ASPQ1 > 0
+nears = stars[ok]
+
+radius = 60 / 3600
+near_ids = set()
+for ii, sp in enumerate(nears):
+    near = agasc.get_agasc_cone(sp['RA'], sp['DEC'], radius=radius, date='2000:001',
+                                agasc_file=agasc1p7)
+    for id in near['AGASC_ID']:
+        if id != sp['AGASC_ID']:
+            near_ids.add(id)
+
+    if ii % 100 == 0:
+        print(ii)
+
+t = Table([list(near_ids)], names=['near_id'])
+t.write('near_neighbor_ids_1p7.fits.gz', format='fits')


### PR DESCRIPTION
For proseco there is legitimate concern about missing stars just above 11.5 mag when considering spoiler stars.  For example a 10.3 candidate acq star would suffer badly from a 11.6 mag star (with a small mag error) that happens to be on the background pixels, and this would currently be accepted as an acq because of more liberal ASPQ1 filtering in proseco.

The main part of this fix is to include in the miniagasc *every* star that is within 60" of a candidate acq or guide star.  That is done via a pre-computed list of such "near neighbor" stars.

Along the way I decided to reduce, not increase, the file size by dropping columns that are basically useless.