### PR TITLE
Make proseco-optimized AGASC file

### DIFF
--- a/agasc/__init__.py
+++ b/agasc/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .agasc import *
 
-__version__ = '4.7'
+__version__ = '4.8'
 
 
 def test(*args, **kwargs):

--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -260,8 +260,7 @@ def get_star(id, agasc_file=None, date=None, fix_color1=True):
 
     with tables_open_file(agasc_file) as h5:
         tbl = h5.root.data
-        tbl_read_where = getattr(tbl, 'read_where', None) or tbl.readWhere
-        id_rows = tbl_read_where('(AGASC_ID == {})'.format(id))
+        id_rows = tbl.read_where('(AGASC_ID == {})'.format(id))
 
     if len(id_rows) > 1:
         raise InconsistentCatalogError(

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -303,3 +303,28 @@ def test_agasc_id(ra, dec, radius=0.2, nstar_limit=5):
                 assert np.all(np.allclose(star1[colname], star2[colname]))
             else:
                 assert star1[colname] == star2[colname]
+
+
+def test_proseco_agasc_1p7():
+    proseco_file = DATA_DIR / 'proseco_agasc_1p7.h5'
+    if not proseco_file.exists():
+        pytest.skip(f'No proseco agasc file {proseco_file} found')
+
+    # Stars looking toward galactic center (dense!)
+    p_stars = agasc.get_agasc_cone(-266, -29, 3,
+                                   agasc_file=proseco_file, date='2000:001')
+    m_stars = agasc.get_agasc_cone(-266, -29, 3,
+                                   agasc_file=AGASC_FILE['1p7'], date='2000:001')
+
+    # Every miniagasc_1p7 star is in proseco_agasc_1p7
+    m_ids = m_stars['AGASC_ID']
+    p_ids = p_stars['AGASC_ID']
+    assert set(m_ids) < set(p_ids)
+
+    # Values are exactly the same
+    p_id_map = {p_ids[idx]: idx for idx in np.arange(len(p_ids))}
+    for m_star in m_stars:
+        m_id = m_star['AGASC_ID']
+        p_star = p_stars[p_id_map[m_id]]
+        for name in p_star.colnames:
+            assert p_star[name] == m_star[name]

--- a/create_mini_agasc_h5.py
+++ b/create_mini_agasc_h5.py
@@ -22,9 +22,9 @@ args = parser.parse_args()
 num_version = re.sub(r'p', '.', args.version)
 
 filename = 'agasc{}.h5'.format(args.version)
-print 'Reading full AGASC {} and selecting useable stars'.format(filename)
+print('Reading full AGASC {} and selecting useable stars'.format(filename))
 
-h5 = tables.openFile(filename)
+h5 = tables.open_file(filename)
 stars = h5.root.data[:]
 h5.close()
 
@@ -37,17 +37,17 @@ if args.proseco or not args.ignore_near_neighbors:
     near_file = 'near_neighbor_ids_{}.fits.gz'.format(args.version)
     near_table = Table.read(near_file, format='fits')
     near_ids = set(near_table['near_id'])
-    print "Including {} near neighbor stars".format(len(near_ids))
+    print("Including {} near neighbor stars".format(len(near_ids)))
     for idx, agasc_id in enumerate(stars['AGASC_ID']):
         if agasc_id in near_ids:
             ok[idx] = True
 
 # Filter down to miniagasc stars
-print 'Filtering from {} to {} stars'.format(len(stars), np.count_nonzero(ok))
+print('Filtering from {} to {} stars'.format(len(stars), np.count_nonzero(ok)))
 stars = stars[ok]
 
 if args.proseco:
-    print 'Excluding columns not needed for proseco'
+    print('Excluding columns not needed for proseco')
     excludes = ['PLX', 'PLX_ERR', 'PLX_CATID',
                 'ACQQ1', 'ACQQ2', 'ACQQ3', 'ACQQ4', 'ACQQ5', 'ACQQ6',
                 'XREF_ID1', 'XREF_ID2', 'XREF_ID3', 'XREF_ID4', 'XREF_ID5',
@@ -56,37 +56,38 @@ if args.proseco:
                 'MAG', 'MAG_ERR', 'MAG_BAND', 'MAG_CATID',
                 'COLOR1_ERR', 'C1_CATID',  # Keep color1, 2, 3
                 'COLOR2_ERR', 'C2_CATID',
-                'RSV2', 'RSV3',
+                'RSV2',
                 'VAR_CATID']
 
     names = [name for name in stars.dtype.names if name not in excludes]
-    print 'Dtype before excluding:\n', stars.dtype
+    print('Dtype before excluding:\n', stars.dtype)
     stars = Table([stars[name] for name in names], names=names, copy=False)
     stars = stars.as_array()
-    print 'Dtype after excluding:\n', stars.dtype
+    print('Dtype after excluding:\n', stars.dtype)
 
-print 'Sorting on Dec and re-ordering'
+print('Sorting on Dec and re-ordering')
 idx = np.argsort(stars['DEC'])
 stars = stars.take(idx)
 
-print 'Creating miniagasc.h5 file'
+print('Creating miniagasc.h5 file')
 rootname = 'proseco_agasc' if args.proseco else 'miniagasc'
 filename = '{}_{}.h5'.format(rootname, args.version)
 
 table_desc, bo = tables.descr_from_dtype(stars.dtype)
-minih5 = tables.openFile(filename, mode='w')
-minitbl = minih5.createTable('/', 'data', table_desc,
-                             title='AGASC {}'.format(num_version))
-print 'Appending stars to {} file'.format(filename)
+minih5 = tables.open_file(filename, mode='w')
+minitbl = minih5.create_table('/', 'data', table_desc,
+                              title='AGASC {}'.format(num_version))
+print('Appending stars to {} file'.format(filename))
 minitbl.append(stars)
 minitbl.flush()
 
-print 'Creating indexes in miniagasc.h5 file'
-minitbl.cols.RA.createCSIndex()
-minitbl.cols.DEC.createCSIndex()
-minitbl.cols.AGASC_ID.createCSIndex()
+print('Creating indexes in miniagasc.h5 file')
+if not args.proseco:
+    minitbl.cols.RA.create_csindex()
+    minitbl.cols.DEC.create_csindex()
+minitbl.cols.AGASC_ID.create_csindex()
 
-print 'Flush and close miniagasc.h5 file'
+print('Flush and close miniagasc.h5 file')
 minitbl.flush()
 minih5.flush()
 minih5.close()


### PR DESCRIPTION
This does a few things:
- Make create_miniagasc_h5.py work in Py3 / Ska3 (no longer works for legacy Ska).
- Add back the RSV3 column
- Remove a pytables2/3 compatibility workaround (just pytables3 now).
- Adds a test of `proseco_agasc_1p7` that it is a strict superset of `miniagasc_1p7` and all the values in common are exactly the same (for a representative sample).

The new output h5 file from create_miniagasc_h5.py may not be Ska legacy compatible, so *DO NOT UPDATE* the production miniagasc_1p7.h5 until Ska legacy is really not being used.

This new version 4.8 does not need to be installed for proseco / matlab development.