### PR TITLE
Make tests pass on Windows

### DIFF
--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -33,8 +33,8 @@ import pytest
 import agasc
 
 # See if we can get to ASCDS environment and mp_get_agasc
-ascrc_file = '{}/.ascrc'.format(os.environ['HOME'])
 try:
+    ascrc_file = '{}/.ascrc'.format(os.environ['HOME'])
     assert os.path.exists(ascrc_file)
     ascds_env = Ska.Shell.getenv('source {} -r release'.format(ascrc_file), shell='tcsh')
     assert 'ASCDS_BIN' in ascds_env


### PR DESCRIPTION
## Description

The `HOME` environment variable that is used to find ~/.ascrc doesn't exist on Windows, but nor will ~/.ascrc.

BTW, the right idiom for this sort of thing is `os.expanduserpath('~/.ascrc')` which works on all platforms.

## Testing

- [x] Passes unit tests on Windows (did not try linux but there is no code change, just putting one line inside the try.
