### PR TITLE
Update supplement MAG_ACA_ERR test

### DIFF
--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -379,7 +379,13 @@ def test_supplement_get_agasc_cone():
     assert np.count_nonzero(stars2['COLOR1'][ok] == 1.49) >= 7
     assert np.count_nonzero(stars2['COLOR1'][ok] == 1.50) == 0
 
-    assert np.all(stars2['MAG_ACA_ERR'][ok] != stars1['MAG_ACA_ERR'][ok])
+    # For the stars that have updated data for the supplement, in this set all of
+    # the errors are smaller or the same, but that may not generalize and this is
+    # an integer column.
+    assert np.all(stars2['MAG_ACA_ERR'][ok] <= stars1['MAG_ACA_ERR'][ok])
+
+    # Similarly, in this set the stars with updated magnitudes are different from
+    # the catalog values.
     assert np.all(stars2['MAG_ACA'][ok] != stars1['MAG_ACA'][ok])
 
     assert np.all(stars2['MAG_ACA_ERR'][~ok] == stars1['MAG_ACA_ERR'][~ok])

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -379,10 +379,10 @@ def test_supplement_get_agasc_cone():
     assert np.count_nonzero(stars2['COLOR1'][ok] == 1.49) >= 7
     assert np.count_nonzero(stars2['COLOR1'][ok] == 1.50) == 0
 
-    # For the stars that have updated data for the supplement, in this set all of
-    # the errors are smaller or the same, but that may not generalize and this is
-    # an integer column.
-    assert np.all(stars2['MAG_ACA_ERR'][ok] <= stars1['MAG_ACA_ERR'][ok])
+    # For the stars that have updated data for the supplement, confirm they don't
+    # have all the same values for MAG_ACA_ERR as the catalog values.  Note this
+    # is an integer column.
+    assert np.any(stars2['MAG_ACA_ERR'][ok] != stars1['MAG_ACA_ERR'][ok])
 
     # Similarly, in this set the stars with updated magnitudes are different from
     # the catalog values.


### PR DESCRIPTION
## Description

Some of the updated values from the supplement matched the catalog
values in the test on the integer MAG_ACA_ERR.  This change updates the test to confirm that the errors are smaller 
or the same coming from the supplement (which may not generalize but appears true here).

I'm still not sure if we have different supplement files in the wild.

## Testing

- [x] Passes unit tests on  linux
- [ ] Functional testing

Fixes #