### PR TITLE
Remove UserWarning on no mag table in supplement

### DIFF
--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -27,7 +27,7 @@ def load_supplement():
         try:
             stars = h5.root.mags
         except tables.NoSuchNodeError:
-            warnings.warn('No observed star magnitude data in agasc_supplement.h5')
+            pass # Will warn on this in future when mags in supplement are used
         else:
             for star in stars:
                 # Use Python int for key not numpy.int32


### PR DESCRIPTION
## Description

Remove UserWarning on no mag table in supplement

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing

Fixes #