### PR TITLE
Fixes in supplement update script (start/stop, input/output, docs)

### DIFF
--- a/agasc/scripts/mag_estimate_report.py
+++ b/agasc/scripts/mag_estimate_report.py
@@ -24,9 +24,9 @@ def parser():
                                       ' Default: now')
     parse.add_argument('--input-dir', default='$SKA/data/agasc',
                        help='Directory containing mag-stats files. Default: $SKA/data/agasc')
-    parse.add_argument('--output-dir', default='$SKA/www/ASPECT/agasc/supplement_reports/suspect',
+    parse.add_argument('--output-dir', default='supplement_reports/suspect',
                        help='Output directory.'
-                            ' Default: $SKA/www/ASPECT/agasc/supplement_reports/suspect')
+                            ' Default: supplement_reports/suspect')
     parse.add_argument('--obs-stats', default='mag_stats_obsid.fits',
                        help='FITS file with mag-stats for all observations.'
                             ' Default: mag_stats_obsid.fits')

--- a/agasc/scripts/mag_estimate_report.py
+++ b/agasc/scripts/mag_estimate_report.py
@@ -65,9 +65,9 @@ def main():
         directory = args.out_dir
         nav_links = None
 
-    msr = mag_estimate_report.MagStatsReport(agasc_stats,
-                                             obs_stats,
-                                             directory=directory)
+    msr = mag_estimate_report.MagEstimateReport(agasc_stats,
+                                                obs_stats,
+                                                directory=directory)
     msr.multi_star_html(sections=sections, tstart=args.start, tstop=args.stop,
                         filename='index.html',
                         nav_links=nav_links)

--- a/agasc/scripts/mag_estimate_report.py
+++ b/agasc/scripts/mag_estimate_report.py
@@ -22,7 +22,7 @@ def parser():
                                       ' CxoTime-compatible time stamp.')
     parse.add_argument('--input-dir', default='$SKA/data/agasc',
                        help='Directory containing mag-stats files')
-    parse.add_argument('--output-dir', default=f'$SKA/www/agasc_supplement_reports/suspect',
+    parse.add_argument('--output-dir', default=f'$SKA/www/ASPECT/agasc/supplement_reports/suspect',
                        help='Output directory')
     parse.add_argument('--obs-stats', default=f'mag_stats_obsid.fits',
                        help='FITS file with mag-stats for all observations')

--- a/agasc/scripts/mag_estimate_report.py
+++ b/agasc/scripts/mag_estimate_report.py
@@ -17,18 +17,24 @@ from agasc.supplement.magnitudes import mag_estimate_report
 def parser():
     parse = argparse.ArgumentParser(description=__doc__)
     parse.add_argument('--start', help='Time to start processing new observations.'
-                                       ' CxoTime-compatible time stamp.')
+                                       ' CxoTime-compatible time stamp.'
+                                       ' Default: now - 90 days')
     parse.add_argument('--stop', help='Time to stop processing new observations.'
-                                      ' CxoTime-compatible time stamp.')
+                                      ' CxoTime-compatible time stamp.'
+                                      ' Default: now')
     parse.add_argument('--input-dir', default='$SKA/data/agasc',
-                       help='Directory containing mag-stats files')
-    parse.add_argument('--output-dir', default=f'$SKA/www/ASPECT/agasc/supplement_reports/suspect',
-                       help='Output directory')
-    parse.add_argument('--obs-stats', default=f'mag_stats_obsid.fits',
-                       help='FITS file with mag-stats for all observations')
-    parse.add_argument('--agasc-stats', default=f'mag_stats_agasc.fits',
-                       help='FITS file with mag-stats for all observed AGASC stars')
-    parse.add_argument('--weekly-report', help="Add links to navigate weekly reports",
+                       help='Directory containing mag-stats files. Default: $SKA/data/agasc')
+    parse.add_argument('--output-dir', default='$SKA/www/ASPECT/agasc/supplement_reports/suspect',
+                       help='Output directory.'
+                            ' Default: $SKA/www/ASPECT/agasc/supplement_reports/suspect')
+    parse.add_argument('--obs-stats', default='mag_stats_obsid.fits',
+                       help='FITS file with mag-stats for all observations.'
+                            ' Default: mag_stats_obsid.fits')
+    parse.add_argument('--agasc-stats', default='mag_stats_agasc.fits',
+                       help='FITS file with mag-stats for all observed AGASC stars.'
+                            ' Default: mag_stats_agasc.fits')
+    parse.add_argument('--weekly-report',
+                       help="Add links to navigate weekly reports.",
                        action='store_true', default=False)
     return parse
 

--- a/agasc/scripts/mag_estimate_report.py
+++ b/agasc/scripts/mag_estimate_report.py
@@ -46,11 +46,11 @@ def main():
     obs_stats = table.Table.read(args.obs_stats)
     obs_stats.convert_bytestring_to_unicode()
 
-    args.start = CxoTime(args.start)
-    if args.stop is None:
-        args.stop = args.start - 90 * units.day
+    args.stop = CxoTime(args.stop)
+    if args.start is None:
+        args.start = args.stop - 90 * units.day
     else:
-        args.stop = CxoTime(args.stop)
+        args.start = CxoTime(args.start)
 
     t = (obs_stats['mp_starcat_time'])
     ok = (t < args.stop) & (t > args.start) & ~obs_stats['obs_ok']

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -38,8 +38,8 @@ def parser():
                        default='.')
     parse.add_argument('--reports-dir',
                        help='Directory where to place reports.'
-                            ' Default: $SKA/www/ASPECT/agasc/supplement_reports/weekly.',
-                       default='$SKA/www/ASPECT/agasc/supplement_reports/weekly')
+                            ' Default: supplement_reports/weekly.',
+                       default='supplement_reports/weekly')
     parse.add_argument('--multi-process',
                        help="Use multi-processing to accelerate run.",
                        action='store_true', default=False)

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -32,7 +32,7 @@ def parser():
                        action='store_true', default=False)
     parse.add_argument('--output-dir',
                        help='Directory where to place the supplement',
-                       default='$SKA/data/agasc')
+                       default='.')
     parse.add_argument('--reports-dir',
                        help='Directory where to place reports',
                        default='$SKA/www/agasc_supplement_reports/weekly')

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -35,7 +35,7 @@ def parser():
                        default='.')
     parse.add_argument('--reports-dir',
                        help='Directory where to place reports',
-                       default='$SKA/www/agasc_supplement_reports/weekly')
+                       default='$SKA/www/ASPECT/agasc/supplement_reports/weekly')
     parse.add_argument('--multi-process', help="Use multi-processing to accelerate run",
                        action='store_true', default=False)
     parse.add_argument('--log-level',

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -15,11 +15,13 @@ def parser():
     parse = argparse.ArgumentParser(description=__doc__)
     parse.add_argument('--agasc-id-file', help='File containing a list of AGASC IDs, one per line.')
     parse.add_argument('--start',
-                       help='Time to start processing new observations.'
+                       help='Include only stars observed after this time.'
                             ' CxoTime-compatible time stamp.')
     parse.add_argument('--stop',
-                       help='Time to stop processing new observations.'
+                       help='Include only stars observed before this time.'
                             ' CxoTime-compatible time stamp.')
+    parse.add_argument('--whole-history',
+                       help='Include all star observations.')
     parse.add_argument('--obs-status-override', help='YAML file with observation status.')
     parse.add_argument('--obs', help='Observation ID for status override.')
     parse.add_argument('--agasc-id', help='AGASC ID for status override.')

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -7,6 +7,8 @@ Update Magnitude Statistics.
 import argparse
 import logging
 from agasc.supplement.magnitudes import update_mag_supplement
+import pathlib
+import os
 
 
 def parser():
@@ -26,6 +28,12 @@ def parser():
     parse.add_argument('--email', help='Email to report errors.')
     parse.add_argument('--report', help='Generate HTML report for the period covered',
                        action='store_true', default=False)
+    parse.add_argument('--output-dir',
+                       help='Directory where to place the supplement',
+                       default='$SKA/data/agasc')
+    parse.add_argument('--reports-dir',
+                       help='Directory where to place reports',
+                       default='$SKA/www/agasc_supplement_reports/weekly')
     parse.add_argument('--multi-process', help="Use multi-processing to accelerate run",
                        action='store_true', default=False)
     parse.add_argument('--log-level',
@@ -37,6 +45,9 @@ def parser():
 def main():
     the_parser = parser()
     args = the_parser.parse_args()
+
+    args.output_dir = pathlib.Path(os.path.expandvars(args.output_dir))
+    args.reports_dir = pathlib.Path(os.path.expandvars(args.reports_dir))
 
     logging.basicConfig(level=args.log_level.upper(),
                         format='%(message)s')

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -38,8 +38,7 @@ def parser():
                        default='.')
     parse.add_argument('--reports-dir',
                        help='Directory where to place reports.'
-                            ' Default: supplement_reports/weekly.',
-                       default='supplement_reports/weekly')
+                            ' Default: <output_dir>/supplement_reports/weekly.')
     parse.add_argument('--multi-process',
                        help="Use multi-processing to accelerate run.",
                        action='store_true', default=False)
@@ -54,7 +53,10 @@ def main():
     args = the_parser.parse_args()
 
     args.output_dir = pathlib.Path(os.path.expandvars(args.output_dir))
-    args.reports_dir = pathlib.Path(os.path.expandvars(args.reports_dir))
+    if args.reports_dir is None:
+        args.reports_dir = args.output_dir / 'supplement_reports' / 'weekly'
+    else:
+        args.reports_dir = pathlib.Path(os.path.expandvars(args.reports_dir))
 
     logging.basicConfig(level=args.log_level.upper(),
                         format='%(message)s')

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -16,10 +16,12 @@ def parser():
     parse.add_argument('--agasc-id-file', help='File containing a list of AGASC IDs, one per line.')
     parse.add_argument('--start',
                        help='Include only stars observed after this time.'
-                            ' CxoTime-compatible time stamp.')
+                            ' CxoTime-compatible time stamp.'
+                            ' Default: now - 14 days.')
     parse.add_argument('--stop',
                        help='Include only stars observed before this time.'
-                            ' CxoTime-compatible time stamp.')
+                            ' CxoTime-compatible time stamp.'
+                            ' Default: now.')
     parse.add_argument('--whole-history',
                        help='Include all star observations.')
     parse.add_argument('--obs-status-override', help='YAML file with observation status.')
@@ -28,15 +30,18 @@ def parser():
     parse.add_argument('--status', help='Status to override.')
     parse.add_argument('--comments', help='Comments for status override.', default='')
     parse.add_argument('--email', help='Email to report errors.')
-    parse.add_argument('--report', help='Generate HTML report for the period covered',
+    parse.add_argument('--report',
+                       help='Generate HTML report for the period covered. Default: False',
                        action='store_true', default=False)
     parse.add_argument('--output-dir',
-                       help='Directory where to place the supplement',
+                       help='Directory where to place the supplement. Default: .',
                        default='.')
     parse.add_argument('--reports-dir',
-                       help='Directory where to place reports',
+                       help='Directory where to place reports.'
+                            ' Default: $SKA/www/ASPECT/agasc/supplement_reports/weekly.',
                        default='$SKA/www/ASPECT/agasc/supplement_reports/weekly')
-    parse.add_argument('--multi-process', help="Use multi-processing to accelerate run",
+    parse.add_argument('--multi-process',
+                       help="Use multi-processing to accelerate run.",
                        action='store_true', default=False)
     parse.add_argument('--log-level',
                        default='info',

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -118,47 +118,55 @@ class MagEstimateReport:
         # this turns all None into '' in a new list of failures
         fails = [{k: '' if v is None else v for k, v in f.items()} for i, f in enumerate(fails)]
 
-        # check how many observations were added in this run, and how many of those are ok
-        new_obs = self.obs_stats[(self.obs_stats['mp_starcat_time'] >= info["tstart"]) &
-                            (self.obs_stats['mp_starcat_time'] <= info["tstop"])]. \
-            group_by('agasc_id')[['agasc_id', 'obsid', 'obs_ok']]. \
-            groups.aggregate(np.count_nonzero)[['agasc_id', 'obsid', 'obs_ok']]
-        new_obs['n_obs_bad_new'] = new_obs['obsid'] - new_obs['obs_ok']
-
-        # add some extra fields
         agasc_stats = self.agasc_stats.copy()
-        if len(agasc_stats) == 0:
-            return [], []
-        all_agasc_ids = np.unique(np.concatenate([
-            new_obs['agasc_id'],
-            [f['agasc_id'] for f in fails]
-        ]))
 
-        assert np.all(np.in1d(agasc_stats['agasc_id'], all_agasc_ids)), 'Not all AGASC IDs are in new obs.'
-        agasc_stats['n_obs_bad'] = agasc_stats['n_obsids'] - agasc_stats['n_obsids_ok']
-        agasc_stats['flag'] = '          '
-        if len(agasc_stats):
+        # check how many observations were added in this run, and how many of those are ok
+        new_obs_mask = ((self.obs_stats['mp_starcat_time'] >= info["tstart"]) &
+                        (self.obs_stats['mp_starcat_time'] <= info["tstop"]))
+        if np.any(new_obs_mask):
+            new_obs = self.obs_stats[new_obs_mask]. \
+                group_by('agasc_id')[['agasc_id', 'obsid', 'obs_ok']]. \
+                groups.aggregate(np.count_nonzero)[['agasc_id', 'obsid', 'obs_ok']]
+            new_obs['n_obs_bad_new'] = new_obs['obsid'] - new_obs['obs_ok']
+
+            all_agasc_ids = np.unique(np.concatenate([
+                new_obs['agasc_id'],
+                [f['agasc_id'] for f in fails]
+            ]))
             agasc_stats = table.join(agasc_stats, new_obs[['agasc_id', 'n_obs_bad_new']],
                                      keys=['agasc_id'])
-        tooltips = {
-            'warning': 'At least one bad observation',
-            'danger': 'At least one new bad observation'
-        }
-        agasc_stats['flag'][:] = ''
-        agasc_stats['flag'][agasc_stats['n_obs_bad'] > 0] = 'warning'
-        agasc_stats['flag'][agasc_stats['n_obs_bad_new'] > 0] = 'danger'
-        agasc_stats['delta'] = (agasc_stats['t_mean_dr3'] - agasc_stats['mag_aca'])
-        agasc_stats['sigma'] = (agasc_stats['t_mean_dr3'] - agasc_stats['mag_aca'])/agasc_stats['mag_aca_err']
-        agasc_stats['new'] = True
-        agasc_stats['new'][np.in1d(agasc_stats['agasc_id'], updated_star_ids)] = False
-        agasc_stats['update_mag_aca'] = np.nan
-        agasc_stats['update_mag_aca_err'] = np.nan
-        agasc_stats['last_obs'] = CxoTime(agasc_stats['last_obs_time']).date
+
+            assert (np.all(np.in1d(agasc_stats['agasc_id'], all_agasc_ids)),
+                    'Not all AGASC IDs are in new obs.')
+
+        # add some extra fields
+        if len(agasc_stats):
+            if not 'n_obs_bad_new' in agasc_stats.colnames:
+                agasc_stats['n_obs_bad_new'] = 0
+            agasc_stats['n_obs_bad'] = agasc_stats['n_obsids'] - agasc_stats['n_obsids_ok']
+            agasc_stats['flag'] = '          '
+            agasc_stats['flag'][:] = ''
+            agasc_stats['flag'][agasc_stats['n_obs_bad'] > 0] = 'warning'
+            agasc_stats['flag'][agasc_stats['n_obs_bad_new'] > 0] = 'danger'
+            agasc_stats['delta'] = (agasc_stats['t_mean_dr3'] - agasc_stats['mag_aca'])
+            agasc_stats['sigma'] = (agasc_stats['t_mean_dr3'] - agasc_stats['mag_aca'])/agasc_stats['mag_aca_err']
+            agasc_stats['new'] = True
+            agasc_stats['new'][np.in1d(agasc_stats['agasc_id'], updated_star_ids)] = False
+            agasc_stats['update_mag_aca'] = np.nan
+            agasc_stats['update_mag_aca_err'] = np.nan
+            agasc_stats['last_obs'] = CxoTime(agasc_stats['last_obs_time']).date
+
         if len(updated_stars):
             agasc_stats['update_mag_aca'][np.in1d(agasc_stats['agasc_id'], updated_star_ids)] = \
                 updated_stars['mag_aca']
             agasc_stats['update_mag_aca_err'][np.in1d(agasc_stats['agasc_id'], updated_star_ids)] =\
                 updated_stars['mag_aca_err']
+
+        tooltips = {
+            'warning': 'At least one bad observation',
+            'danger': 'At least one new bad observation'
+        }
+
         # make all individual star reports
         star_reports = {}
         for agasc_id in np.atleast_1d(agasc_ids):

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -136,8 +136,8 @@ class MagEstimateReport:
             agasc_stats = table.join(agasc_stats, new_obs[['agasc_id', 'n_obs_bad_new']],
                                      keys=['agasc_id'])
 
-            assert (np.all(np.in1d(agasc_stats['agasc_id'], all_agasc_ids)),
-                    'Not all AGASC IDs are in new obs.')
+            assert np.all(np.in1d(agasc_stats['agasc_id'], all_agasc_ids)
+                          ), 'Not all AGASC IDs are in new obs.'
 
         # add some extra fields
         if len(agasc_stats):

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -448,8 +448,8 @@ def do(args):
                 'up': '..',
                 'next': f'../{(t + week).date[:8]}/index.html'
             }
-            report = msr.MagStatsReport(agasc_stats, obs_stats,
-                                        directory=os.path.join('weekly_reports', f'{t.date[:8]}'))
+            report = msr.MagEstimateReport(agasc_stats, obs_stats,
+                                           directory=os.path.join('weekly_reports', f'{t.date[:8]}'))
             report.multi_star_html(filename='index.html',
                                    sections=sections,
                                    updated_stars=updated_stars,

--- a/docs/supplement.rst
+++ b/docs/supplement.rst
@@ -2,6 +2,24 @@
 Updating the AGASC Supplement
 ====================================
 
+The AGASC magnitude supplement is updated on a weekly basis. A call like the following updates the supplement file
+located in $SKA/data/agasc, and produces html reports in $SKA/www/ASPECT/agasc_supplement_reports::
+
+    agasc-supplement-update --report
+
+By default, this considers only the observations recorded in the two weeks prior. In other words,
+this is equivalent to::
+
+    agasc-supplement-update --start `date -I --date="14 days ago"` --stop `date -I`
+
+The report of suspicious observations (over the last 90 days) is generated using::
+
+    agasc-mag-estimate-report --start `date -I --date="90 days ago"` --stop `date -I`
+
+In order to produce the reports, the script uses two files that contain observed magnitude data.
+These files are placed in the same directory as the supplement file (usually $SKA/data/agasc).
+The location of these files can be specified in the command line. More information below.
+
 Scripts
 -------
 


### PR DESCRIPTION
## Description

This PR introduces a few changes, one of which is a bug fix:
- bug fix: MagStatsReport was renamed MagEstimateReport when moving the project to agasc. Fix one script that was not changed accordingly.
- Added --output-dir, --input-dir, and --reports-dir arguments to the mag-stats scripts.This includes some sensible defaults for weekly runs. Replaced uses of os.path by pathlib.
- Restructured the start/stop arguments so the default matches the weekly run.
- Slightly improved the documentation of the scripts used to update the magnitude supplement.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing. Ran with several start/stop options (including empty intervals) and output directory options to update supplement and produce reports.
  

Fixes #