### PR TITLE
Improved access to AGASC supplement

### DIFF
--- a/agasc/__init__.py
+++ b/agasc/__init__.py
@@ -2,6 +2,8 @@
 import ska_helpers
 
 from .agasc import *  # noqa
+from .supplement.utils import *  # noqa
+from .paths import *  # noqa
 
 __version__ = ska_helpers.get_version(__package__)
 

--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -420,12 +420,16 @@ def update_from_supplement(stars):
     in-place in the input ``stars`` Table:
 
     - ``MAG_ACA`` and ``MAG_ACA_ERR`` are set according to the supplement.
-    - ``MAG_CATID`` (mag catalog ID) is set to ``MAG_CATID_SUPPLEMENT`` (128).
+    - ``MAG_CATID`` (mag catalog ID) is set to ``MAG_CATID_SUPPLEMENT``.
     - If COLOR1 is 0.7 or 1.5 then it is changed to 0.69 or 1.49 respectively.
+      Those particular values do not matter except that they are different from
+      the "status flag" values of 0.7 (no color => very unreliable mag estimate)
+      or 1.5 (red star => somewhat unreliable mag estimate) that have special
+      meaning based on deep heritage in the AGASC catalog itself.
 
     Stars which are in the bad stars table are updated as follows:
 
-    - ``CLASS = 100 + bad star source id``
+    - ``CLASS = BAD_CLASS_SUPPLEMENT``
 
     This functionality is gloabally disabled if the environment variable
     ``AGASC_DISABLE_SUPPLEMENT`` is set to any value.
@@ -466,4 +470,4 @@ def update_from_supplement(stars):
                     star['COLOR1'] = color1 - 0.01
 
         if agasc_id in bad_stars:
-            set_star(star, 'CLASS', BAD_CLASS_SUPPLEMENT + bad_stars[agasc_id]['source'])
+            set_star(star, 'CLASS', BAD_CLASS_SUPPLEMENT)

--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -21,21 +21,26 @@ MAG_CATID_SUPPLEMENT = 100
 BAD_CLASS_SUPPLEMENT = 100
 
 RA_DECS_CACHE = {}
-COMMON_DOC = """\
-If ``use_supplement`` is ``True`` and there is no ``AGASC_DISABLE_SUPPLEMENT``
-    environment variable set, then stars with available mag estimates or bad
+COMMON_DOC = """If ``use_supplement`` is ``True`` and the ``AGASC_DISABLE_SUPPLEMENT``
+    environment variable is not set, then stars with available mag estimates or bad
     star entries in the AGASC supplement are updated in-place in the output
     ``stars`` Table:
 
     - ``MAG_ACA`` and ``MAG_ACA_ERR`` are set according to the supplement.
-    - ``MAG_CATID`` (mag catalog ID) is set to ``MAG_CATID_SUPPLEMENT`` (100).
+    - ``MAG_CATID`` (mag catalog ID) is set to ``agasc.MAG_CATID_SUPPLEMENT``.
     - If ``COLOR1`` is 0.7 or 1.5 then it is changed to 0.69 or 1.49 respectively.
+      Those particular values do not matter except that they are different from
+      the "status flag" values of 0.7 (no color => very unreliable mag estimate)
+      or 1.5 (red star => somewhat unreliable mag estimate) that have special
+      meaning based on deep heritage in the AGASC catalog itself.
     - If ``AGASC_ID`` is in the supplement bad stars table then CLASS is set to
-      ``100 + <source>``, where ``<source>`` is the bad star source identifier.
+      ``agasc.BAD_CLASS_SUPPLEMENT``.
 
     The default ``agasc_file`` is ``<AGASC_DIR>/miniagasc.h5``, where
     ``<AGASC_DIR>`` is either the ``AGASC_DIR`` environment variable if defined
-    or ``$SKA/data/agasc``."""
+    or ``$SKA/data/agasc``.
+
+    The default AGASC supplement file is ``<AGASC_DIR>/agasc_supplement.h5``."""
 
 
 class disable_supplement(ContextDecorator):

--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -240,7 +240,7 @@ def add_pmcorr_columns(stars, date):
 
 
 def get_agasc_cone(ra, dec, radius=1.5, date=None, agasc_file=None,
-                   pm_filter=True, fix_color1=True, use_supplement=False):
+                   pm_filter=True, fix_color1=True, use_supplement=True):
     """
     Get AGASC catalog entries within ``radius`` degrees of ``ra``, ``dec``.
 
@@ -300,7 +300,7 @@ def get_agasc_cone(ra, dec, radius=1.5, date=None, agasc_file=None,
     return stars
 
 
-def get_star(id, agasc_file=None, date=None, fix_color1=True, use_supplement=False):
+def get_star(id, agasc_file=None, date=None, fix_color1=True, use_supplement=True):
     """
     Get AGASC catalog entry for star with requested id.
 
@@ -362,7 +362,7 @@ def get_star(id, agasc_file=None, date=None, fix_color1=True, use_supplement=Fal
     return t[0]
 
 
-def get_stars(ids, agasc_file=None, dates=None, fix_color1=True, use_supplement=False):
+def get_stars(ids, agasc_file=None, dates=None, fix_color1=True, use_supplement=True):
     """
     Get AGASC catalog entries for star ``ids`` at ``dates``.
 

--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -551,10 +551,11 @@ def update_from_supplement(stars):
 
     # Get estimate mags and errs from supplement as a dict of dict
     # agasc_id : {mag_aca: .., mag_aca_err: ..}.
-    supplement_mags = get_supplement_table('mags', as_dict=True)
+    supplement_mags = get_supplement_table('mags', agasc_dir=default_agasc_dir(),
+                                           as_dict=True)
 
     # Get bad stars as {agasc_id: {source: ..}}
-    bad_stars = get_supplement_table('bad', as_dict=True)
+    bad_stars = get_supplement_table('bad', agasc_dir=default_agasc_dir(), as_dict=True)
 
     for star in stars:
         agasc_id = int(star['AGASC_ID'])

--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -61,11 +61,11 @@ def set_supplement_enabled(value):
 
       import agasc
 
-      # Disable use of the supplement
+      # Disable use of the supplement for the context block
       with agasc.set_supplement_enabled(False):
           aca = proseco.get_aca_catalog(obsid=8008)
 
-      # Allow using the supplement
+      # Disable use of the supplement for the function
       @agasc.set_supplement_enabled(False)
       def test_get_aca_catalog():
           aca = proseco.get_aca_catalog(obsid=8008)

--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -25,7 +25,7 @@ __all__ = ['sphere_dist', 'get_agasc_cone', 'get_star', 'get_stars',
 # excluding stars based on the bad stars table.
 
 SUPPLEMENT_ENABLED_ENV = 'AGASC_SUPPLEMENT_ENABLED'
-SUPPLEMENT_ENABLED_DEFAULT = 'False'
+SUPPLEMENT_ENABLED_DEFAULT = 'True'
 MAG_CATID_SUPPLEMENT = 100
 BAD_CLASS_SUPPLEMENT = 100
 

--- a/agasc/paths.py
+++ b/agasc/paths.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import os
+from pathlib import Path
+
+SUPPLEMENT_FILENAME = 'agasc_supplement.h5'
+
+
+__all__ = ['default_agasc_dir', 'default_agasc_file', 'SUPPLEMENT_FILENAME']
+
+
+def default_agasc_dir():
+    """Path to the AGASC directory.
+
+    This returns the ``AGASC_DIR`` environment variable if defined, otherwise
+    ``$SKA/data/agasc``.
+
+    :returns: Path
+    """
+    if 'AGASC_DIR' in os.environ:
+        out = Path(os.environ['AGASC_DIR'])
+    else:
+        out = Path(os.environ['SKA'], 'data', 'agasc')
+    return out
+
+
+def default_agasc_file():
+    """Default main AGASC file ``agasc_dir() / miniagasc.h5``.
+
+    :returns: str
+    """
+    return str(default_agasc_dir() / 'miniagasc.h5')

--- a/agasc/supplement/utils.py
+++ b/agasc/supplement/utils.py
@@ -1,0 +1,75 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from pathlib import Path
+import warnings
+
+from ska_helpers.utils import lru_cache_timed
+import tables
+from astropy.table import Table
+
+from ..paths import SUPPLEMENT_FILENAME, default_agasc_dir
+
+
+__all__ = ['get_supplement_table']
+
+
+@lru_cache_timed(timeout=3600)
+def get_supplement_table(name, agasc_dir=None, as_dict=False):
+    """Get one of the tables in the AGASC supplement.
+
+    This function gets one of the supplement tables, specified with ``name``:
+
+    - ``bad``: Bad stars (agasc_id, source)
+    - ``mags``: Estimated mags (agasc_id, mag_aca mag_aca_err)
+    - ``obs``: Star-obsid status for mag estimation (agasc_id, obsid, ok,
+      comments)
+
+    This function is cached with a timeout of an hour, so you can call it
+    repeatedly with no penalty in performance.
+
+    If ``as_dict=False`` (default) then the table is returned as an astropy
+    ``Table``.
+
+    If ``as_dict=True`` then the table is returned as a dict of {key: value}
+    pairs. For ``mags`` and ``bad``, the key is ``agasc_id``. For ``obs`` the
+    key is the ``(agasc_id, obsid)`` tuple. In all cases the value is a dict
+    of the remaining columns.
+
+    :param name: Table name within the AGASC supplement HDF5 file
+    :param data_root: directory containing the AGASC supplement HDF5 file
+        (default=same directory as the AGASC file)
+    :param as_dict: return result as a dictionary (default=False)
+
+    :returns: supplement table as ``Table`` or ``dict``
+    """
+    agasc_dir = default_agasc_dir() if agasc_dir is None else Path(agasc_dir)
+
+    if name not in ('mags', 'bad', 'obs'):
+        raise ValueError("table name must be one of 'mags', 'bad', or 'obs'")
+
+    supplement_file = agasc_dir / SUPPLEMENT_FILENAME
+    with tables.open_file(supplement_file) as h5:
+        try:
+            dat = getattr(h5.root, name)[:]
+        except tables.NoSuchNodeError:
+            warnings.warn(f"No dataset '{name}' in {supplement_file},"
+                          " returning empty table")
+            dat = []
+
+    if as_dict:
+        out = {}
+        keys_names = {
+            'mags': ['agasc_id'],
+            'bad': ['agasc_id'],
+            'obs': ['agasc_id', 'obsid']}
+        key_names = keys_names[name]
+        for row in dat:
+            # Make the key, coercing the values from numpy to native Python
+            key = tuple(row[nm].item() for nm in key_names)
+            if len(key) == 1:
+                key = key[0]
+            # Make the value from the remaining non-key column names
+            out[key] = {nm: row[nm].item() for nm in row.dtype.names if nm not in key_names}
+    else:
+        out = Table(dat)
+
+    return out

--- a/agasc/tests/test_agasc_1.py
+++ b/agasc/tests/test_agasc_1.py
@@ -1,15 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 import tempfile
-from pathlib import Path
 
 import numpy as np
 import tables
 from astropy.table import Table
 
 from .. import agasc
-
-DATA_ROOT = Path(os.environ['SKA'], 'data', 'agasc')
 
 
 def test_multi_agasc():
@@ -18,7 +15,7 @@ def test_multi_agasc():
 
     # Make two custom agasc files from the miniagasc, using 20 stars from
     # around the middle of the table
-    with tables.open_file(DATA_ROOT / 'miniagasc.h5') as h5:
+    with tables.open_file(agasc.default_agasc_file()) as h5:
         middle = int(len(h5.root.data) // 2)
         stars1 = Table(h5.root.data[middle: middle + 20])
         stars1.write(os.path.join(tempdir, 'stars1.h5'), path='data')

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -468,10 +468,9 @@ def test_get_supplement_table_bad_dict():
 
 
 def test_get_bad_star_with_supplement():
-    bad = agasc.get_supplement_table('bad', as_dict=True)
     agasc_id = 797847184
     star = agasc.get_star(agasc_id, use_supplement=True)
-    assert star['CLASS'] == agasc.BAD_CLASS_SUPPLEMENT + bad[agasc_id]['source']
+    assert star['CLASS'] == agasc.BAD_CLASS_SUPPLEMENT
 
 
 @pytest.mark.skipif(NO_MAGS_IN_SUPPLEMENT, reason='no mags in supplement')

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -365,7 +365,7 @@ def test_proseco_agasc_1p7():
 def test_supplement_get_agasc_cone():
     ra, dec = 282.53, -0.38  # Obsid 22429 with a couple of color1=1.5 stars
     stars1 = agasc.get_agasc_cone(ra, dec, date='2021:001')
-    stars2 = agasc.get_agasc_cone(ra, dec, date='2021:001', use_mag_est=True)
+    stars2 = agasc.get_agasc_cone(ra, dec, date='2021:001', use_supplement=True)
     ok = stars2['MAG_CATID'] == agasc.MAG_CATID_SUPPLEMENT
 
     change_names = ['MAG_CATID', 'COLOR1', 'MAG_ACA', 'MAG_ACA_ERR']
@@ -401,7 +401,7 @@ def test_supplement_get_agasc_cone():
 def test_supplement_get_star():
     agasc_id = 58720672
     star1 = agasc.get_star(agasc_id)
-    star2 = agasc.get_star(agasc_id, use_mag_est=True)
+    star2 = agasc.get_star(agasc_id, use_supplement=True)
     assert star1['MAG_CATID'] != agasc.MAG_CATID_SUPPLEMENT
     assert star2['MAG_CATID'] == agasc.MAG_CATID_SUPPLEMENT
 
@@ -415,10 +415,21 @@ def test_supplement_get_star():
 
 
 @pytest.mark.skipif('not HAS_MAGS_IN_SUPPLEMENT')
+def test_supplement_get_star_disable():
+    """Test that disable_supplement_mags decorator works"""
+    get_star_no_supp = agasc.disable_supplement(agasc.get_star)
+    agasc_id = 58720672
+    star1 = agasc.get_star(agasc_id, date='2020:001')
+    star2 = get_star_no_supp(agasc_id, date='2020:001', use_supplement=True)
+    for name in star1.colnames:
+        assert star1[name] == star2[name]
+
+
+@pytest.mark.skipif('not HAS_MAGS_IN_SUPPLEMENT')
 def test_supplement_get_stars():
     agasc_ids = [58720672, 670303120]
     star1 = agasc.get_stars(agasc_ids)
-    star2 = agasc.get_stars(agasc_ids, use_mag_est=True)
+    star2 = agasc.get_stars(agasc_ids, use_supplement=True)
     assert np.all(star1['MAG_CATID'] != agasc.MAG_CATID_SUPPLEMENT)
     assert np.all(star2['MAG_CATID'] == agasc.MAG_CATID_SUPPLEMENT)
 

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -48,7 +48,8 @@ except Exception:
     DS_AGASC_VERSION = None
 
 
-HAS_MAGS_IN_SUPPLEMENT = any(agasc.agasc.SUPPLEMENT)
+HAS_MAGS_IN_SUPPLEMENT = any(agasc.get_supplement_table('mags', as_dict=True))
+HAS_OBS_IN_SUPPLEMENT = any(agasc.get_supplement_table('obs', as_dict=True))
 
 HAS_KSH = os.path.exists('/bin/ksh')  # dependency of mp_get_agascid
 
@@ -427,3 +428,49 @@ def test_supplement_get_stars():
     assert np.allclose(star2['COLOR1'], [1.49, 0.24395067])
 
     assert np.all(star2['MAG_ACA'] != star1['MAG_ACA'])
+
+
+def test_get_supplement_table_bad():
+    bad = agasc.get_supplement_table('bad')
+    assert isinstance(bad, Table)
+    assert bad.colnames == ['agasc_id', 'source']
+    assert len(bad) > 3300
+    assert 797847184 in bad['agasc_id']
+
+
+def test_get_supplement_table_bad_dict():
+    bad = agasc.get_supplement_table('bad', as_dict=True)
+    assert isinstance(bad, dict)
+    assert len(bad) > 3300
+    assert bad[797847184] == {'source': 1}
+
+
+@pytest.mark.skipif('not HAS_MAGS_IN_SUPPLEMENT')
+def test_get_supplement_table_mags():
+    mags = agasc.get_supplement_table('mags')
+    assert isinstance(mags, Table)
+    assert 131736 in mags['agasc_id']
+    assert len(mags) > 80000
+    assert mags.colnames == ['agasc_id', 'mag_aca', 'mag_aca_err', 'last_obs_time']
+
+
+@pytest.mark.skipif('not HAS_MAGS_IN_SUPPLEMENT')
+def test_get_supplement_table_mags_dict():
+    mags = agasc.get_supplement_table('mags', as_dict=True)
+    assert isinstance(mags, dict)
+    assert 131736 in mags
+    assert len(mags) > 80000
+    assert list(mags[131736].keys()) == ['mag_aca', 'mag_aca_err', 'last_obs_time']
+
+
+@pytest.mark.skipif('not HAS_OBS_IN_SUPPLEMENT')
+def test_get_supplement_table_obs():
+    obs = agasc.get_supplement_table('obs')
+    assert isinstance(obs, Table)
+    assert obs.colnames == ['obsid', 'agasc_id', 'ok', 'comments']
+
+
+@pytest.mark.skipif('not HAS_OBS_IN_SUPPLEMENT')
+def test_get_supplement_table_obs_dict():
+    obs = agasc.get_supplement_table('obs', as_dict=True)
+    assert isinstance(obs, dict)

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -362,6 +362,7 @@ def test_proseco_agasc_1p7():
 
 
 @pytest.mark.skipif(NO_MAGS_IN_SUPPLEMENT, reason='no mags in supplement')
+@agasc.set_supplement_enabled(True)
 def test_supplement_get_agasc_cone():
     ra, dec = 282.53, -0.38  # Obsid 22429 with a couple of color1=1.5 stars
     stars1 = agasc.get_agasc_cone(ra, dec, date='2021:001')
@@ -398,6 +399,7 @@ def test_supplement_get_agasc_cone():
 
 
 @pytest.mark.skipif(NO_MAGS_IN_SUPPLEMENT, reason='no mags in supplement')
+@agasc.set_supplement_enabled(True)
 def test_supplement_get_star():
     agasc_id = 58720672
     star1 = agasc.get_star(agasc_id)
@@ -415,18 +417,19 @@ def test_supplement_get_star():
 
 
 @pytest.mark.skipif(NO_MAGS_IN_SUPPLEMENT, reason='no mags in supplement')
+@agasc.set_supplement_enabled(True)
 def test_supplement_get_star_disable_context_manager():
     """Test that disable_supplement_mags context manager works"""
     agasc_id = 58720672
     star1 = agasc.get_star(agasc_id, date='2020:001')
-    with agasc.disable_supplement():
+    with agasc.set_supplement_enabled(False):
         star2 = agasc.get_star(agasc_id, date='2020:001', use_supplement=True)
     for name in star1.colnames:
         assert star1[name] == star2[name]
 
 
 @pytest.mark.skipif(NO_MAGS_IN_SUPPLEMENT, reason='no mags in supplement')
-@agasc.disable_supplement()
+@agasc.set_supplement_enabled(False)
 def test_supplement_get_star_disable_decorator():
     """Test that disable_supplement_mags context manager works"""
     agasc_id = 58720672
@@ -437,6 +440,7 @@ def test_supplement_get_star_disable_decorator():
 
 
 @pytest.mark.skipif(NO_MAGS_IN_SUPPLEMENT, reason='no mags in supplement')
+@agasc.set_supplement_enabled(True)
 def test_supplement_get_stars():
     agasc_ids = [58720672, 670303120]
     star1 = agasc.get_stars(agasc_ids)
@@ -467,6 +471,7 @@ def test_get_supplement_table_bad_dict():
     assert bad[797847184] == {'source': 1}
 
 
+@agasc.set_supplement_enabled(True)
 def test_get_bad_star_with_supplement():
     agasc_id = 797847184
     star = agasc.get_star(agasc_id, use_supplement=True)

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -456,6 +456,13 @@ def test_get_supplement_table_bad_dict():
     assert bad[797847184] == {'source': 1}
 
 
+def test_get_bad_star_with_supplement():
+    bad = agasc.get_supplement_table('bad', as_dict=True)
+    agasc_id = 797847184
+    star = agasc.get_star(agasc_id, use_supplement=True)
+    assert star['CLASS'] == agasc.BAD_CLASS_SUPPLEMENT + bad[agasc_id]['source']
+
+
 @pytest.mark.skipif('not HAS_MAGS_IN_SUPPLEMENT')
 def test_get_supplement_table_mags():
     mags = agasc.get_supplement_table('mags')

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,3 +4,9 @@ API documentation
 
 .. automodule:: agasc.agasc
    :members:
+
+.. automodule:: agasc.paths
+   :members:
+
+.. automodule:: agasc.supplement.utils
+   :members:

--- a/docs/catalog-description.rst
+++ b/docs/catalog-description.rst
@@ -221,7 +221,8 @@ following fields for each entry::
             5 - potential artifact
             6 - known multiple system
             7 - close to galaxy or other extended object
-          128 - bad star in AGASC supplement (only via agasc package query)
+         >100 - bad star in AGASC supplement (only via agasc package query);
+                class = 100 + bad star source ID.
 
         Note that code 1 is used only for a few hand-entered errata in
         or for galaxies with matches to preliminary 2MASS galaxy catalog.
@@ -267,7 +268,7 @@ following fields for each entry::
             4 - ACT
             5 - Tycho-2
             6 - GSC-ACT
-          128 - Chandra ACA estimated magnitude (only via agasc package query)
+          100 - Chandra ACA estimated magnitude (only via agasc package query)
 
     4    COLOR1 - float variable expressing the cataloged or estimated B-V color,
         used for mag_aca, in mag.  If no colors are available, the default

--- a/docs/catalog-description.rst
+++ b/docs/catalog-description.rst
@@ -221,6 +221,7 @@ following fields for each entry::
             5 - potential artifact
             6 - known multiple system
             7 - close to galaxy or other extended object
+          128 - bad star in AGASC supplement (only via agasc package query)
 
         Note that code 1 is used only for a few hand-entered errata in
         or for galaxies with matches to preliminary 2MASS galaxy catalog.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,19 @@ AGASC Catalog Description and History
 
    catalog-description
 
+
+Getting started
+---------------
+
+The most common usage of the ``agasc`` package is getting the AGASC catalog data
+for stars near a location on the sky or by AGASC ID.
+
+The three main functions are:
+
+- :func:`~agasc.agasc.get_agasc_cone`: Get stars within a radius of RA, Dec
+- :func:`~agasc.agasc.get_star`: Get information for one star by AGASC ID
+- :func:`~agasc.agasc.get_stars`: Get information for a list of stars by AGASC ID
+
 ``agasc`` package API documentation
 -----------------------------------
 .. toctree::


### PR DESCRIPTION
## Description

This adds a new function `agasc.get_supplement_table()` which should be the primary external way to access the AGASC supplement. With this it is possible to get any of the 3 tables as either a `Table` or a keyed dict.

It also fixes a bug that showed up in functional testing with `proseco`, namely that the `proseco_agasc_1p7.h5` file doesn't have a `MAG_CATID` so the update code was failing due to a key error.

The function is cached with a one-hour timeout, so a long-lived process will get any updates that occur in the meantime.

## Testing

Testing used the current `agasc_supplement.h5` file from `/proj/sot/ska/jgonzalez/miniconda3/envs/agasc/data/agasc` (if I got that path right from memory), except that I added one entry to the `obs` table.

- [x] Passes unit tests on MacOS
- [x] Functional testing

### Functional testing

Also used this with `proseco` via and sparkles via https://github.com/sot/proseco/pull/345 and `sparkles` via https://github.com/sot/sparkles/pull/149.