### PR TITLE
Faster get_stars() function

### DIFF
--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -385,7 +385,7 @@ def _get_rows_read_entire(ids_1d, dates_1d, agasc_file):
     return rows
 
 
-def get_stars(ids, agasc_file=None, dates=None, read_entire_agasc=5000, fix_color1=True,
+def get_stars(ids, agasc_file=None, dates=None, method_threshold=5000, fix_color1=True,
               use_supplement=None):
     """
     Get AGASC catalog entries for star ``ids`` at ``dates``.
@@ -399,7 +399,7 @@ def get_stars(ids, agasc_file=None, dates=None, read_entire_agasc=5000, fix_colo
     HDF5 file, or by reading the entire table into memory and doing the search
     by making a dict index by AGASC ID. Tests indicate that the latter is faster
     for about 5000 or more stars, so this function will read the entire AGASC if
-    the number of stars is greater than ``read_entire_agasc``.
+    the number of stars is greater than ``method_threshold``.
 
     Unlike the similar ``get_star`` function, this adds a ``DATE`` column
     indicating the date at which the star coordinates (RA_PMCORR, DEC_PMCORR)
@@ -447,7 +447,7 @@ def get_stars(ids, agasc_file=None, dates=None, read_entire_agasc=5000, fix_colo
     ids, dates = np.broadcast_arrays(ids, dates_in)
     ids_1d, dates_1d = np.atleast_1d(ids), np.atleast_1d(dates)
 
-    if len(ids_1d) < read_entire_agasc:
+    if len(ids_1d) < method_threshold:
         rows = _get_rows_read_where(ids_1d, dates_1d, agasc_file)
         method = 'tables_read_where'
     else:

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -262,6 +262,22 @@ def test_get_stars3():
     assert np.allclose(stars['MAG_ACA'], mags)
 
 
+def test_get_stars_many():
+    """Test get_stars() with at least GET_STARS_METHOD_THRESHOLD (5000) stars"""
+    from .. import agasc
+    stars = agasc.get_agasc_cone(0, 0, radius=0.5)
+    agasc_ids = stars['AGASC_ID']
+    stars1 = agasc.get_stars(agasc_ids, dates='2020:001')  # read_where method
+    stars2 = agasc.get_stars(agasc_ids, dates='2020:001', read_entire_agasc=1)  # read entire AGASC
+
+    assert stars1.get_stars_method == 'tables_read_where'
+    assert stars2.get_stars_method == 'read_entire_agasc'
+
+    assert stars1.colnames == stars2.colnames
+    for name in stars1.colnames:
+        assert np.all(stars1[name] == stars2[name])
+
+
 def test_float16():
     stars = agasc.get_agasc_cone(np.float16(219.90279), np.float16(-60.83358), .015)
     assert stars['AGASC_ID'][0] == 1180612176

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -268,7 +268,7 @@ def test_get_stars_many():
     stars = agasc.get_agasc_cone(0, 0, radius=0.5)
     agasc_ids = stars['AGASC_ID']
     stars1 = agasc.get_stars(agasc_ids, dates='2020:001')  # read_where method
-    stars2 = agasc.get_stars(agasc_ids, dates='2020:001', read_entire_agasc=1)  # read entire AGASC
+    stars2 = agasc.get_stars(agasc_ids, dates='2020:001', method_threshold=1)  # read entire AGASC
 
     assert stars1.get_stars_method == 'tables_read_where'
     assert stars2.get_stars_method == 'read_entire_agasc'


### PR DESCRIPTION
## Description

For getting stars by AGASC_ID, at some point it is faster to just read the entire AGASC catalog into memory. This PR implements that method using a threshold of 5000 stars. That value was determined based on testing on my laptop.

## Testing

- [x] Passes unit tests on MacOS.
- [x] Functional testing

### Functional testing

For the AGASC supplement with about 81000 stars, the original (`tables.read_where()`) method takes about 80 seconds, while the new method takes about 13 seconds.