### PR TITLE
Add flake8 check to GitHub workflows

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,21 @@
+name: Python flake8 check
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # Note: only check files in Ska.engarchive package.  Many other files in
+        # the repo are not maintained as PEP8 compliant.
+        flake8 agasc setup.py --count --ignore=E402,W503,F541 --max-line-length=100 --show-source --statistics


### PR DESCRIPTION
## Description

Add flake8 checking to ensure compliance with [Ska Python style guide](https://occweb.cfa.harvard.edu/twiki/bin/view/Aspect/SkaPython#Check_and_maintain_PEP8_and_flak)

## Testing

- [N/A] Passes unit tests on MacOS, linux, Windows (at least one required)
- [fail] Functional testing

Code fails flake8 now, will need to do cleanup in a later PR to avoid a mess of merge conflicts.