### PR TITLE
Bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,16 @@ mp_get_agasc_bug.png
 miniagasc.h5
 ra_dec.npy
 agasc1p6.h5
-doc/_*
+docs/_*
 build
 data/
 dist/
 MANIFEST
 parsetab.py
 __pycache__
+.vscode
+.DS_store
+_*
+*~
+supplement_reports
+test

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -77,6 +77,13 @@ def main():
     else:
         args.reports_dir = Path(os.path.expandvars(args.reports_dir))
 
+    if args.whole_history:
+        if args.start or args.stop:
+            logger.error('--whole-history argument is incompatible with --start/--stop arguments')
+            the_parser.exit(1)
+        args.start = None
+        args.stop = None
+
     pyyaks.logger.get_logger(
         name='agasc.supplement',
         level=args.log_level.upper(),

--- a/agasc/scripts/update_obs_status.py
+++ b/agasc/scripts/update_obs_status.py
@@ -115,16 +115,21 @@ def update_obs_table(filename, obs_status_override, dry_run=False):
     if not update:
         return
 
+    obs_dtype = np.dtype([
+        ('obsid', np.int32),
+        ('agasc_id', np.int32),
+        ('ok', np.int32),
+        ('comments', '<U80')])
     if obs_status:
         t = list(zip(
             *[[oi, ai, np.uint(obs_status[(oi, ai)]['ok']), obs_status[(oi, ai)]['comments']]
               for oi, ai in obs_status]
         ))
-        obs_status = table.Table(t, names=['obsid', 'agasc_id', 'ok', 'comments'])
+        obs_status = table.Table(t, names=obs_dtype.names,
+                                 dtype=[obs_dtype[name] for name in obs_dtype.names])
     else:
         logger.info('creating empty obs table')
-        dtype = [('obsid', int), ('agasc_id', int), ('ok', np.uint), ('comments', '<U80')]
-        obs_status = table.Table(dtype=dtype)
+        obs_status = table.Table(dtype=obs_dtype)
 
     if not dry_run:
         obs_status.write(str(filename), format='hdf5', path='obs', append=True, overwrite=True)

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -469,9 +469,9 @@ def do(output_dir,
                 report = msr.MagEstimateReport(agasc_stats, obs_stats, directory=directory)
                 report.multi_star_html(**multi_star_html_args)
                 latest = reports_dir / 'latest'
-                if latest.exists():
+                if os.path.lexists(latest):
                     latest.unlink()
-                latest.symlink_to(directory)
+                latest.symlink_to(directory.absolute())
             except Exception as e:
                 logger.error(f'Exception when creating report: {e}')
                 multi_star_html_args['directory'] = directory

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -312,11 +312,6 @@ def do(output_dir,
     # as ascii. It displays a warning which I want to avoid:
     warnings.filterwarnings("ignore", category=tables.exceptions.FlavorWarning)
 
-    if start:
-        start = CxoTime(start)
-    if stop:
-        stop = CxoTime(stop)
-
     filename = output_dir / 'agasc_supplement.h5'
 
     if multi_process:
@@ -329,19 +324,15 @@ def do(output_dir,
 
     # set start/stop times and agasc_ids
     if whole_history or agasc_ids is not None:
-        if start:
-            logger.warning('Ignoring --start argument from commant line')
-        if stop:
-            logger.warning('Ignoring --stop argument from commant line')
+        if start or stop:
+            raise ValueError('incompatible arguments: whole_history and start/stop')
         start = CxoTime(star_obs_catalogs.STARS_OBS['mp_starcat_time']).min().date
         stop = CxoTime(star_obs_catalogs.STARS_OBS['mp_starcat_time']).max().date
         if agasc_ids is None:
             agasc_ids = sorted(star_obs_catalogs.STARS_OBS['agasc_id'])
     else:
-        if not stop:
-            stop = CxoTime.now().date
-        if not start:
-            start = (CxoTime(stop) - 14 * u.day).date
+        stop = CxoTime(stop).date if stop else CxoTime.now().date
+        start = CxoTime(start).date if start else (CxoTime(stop) - 14 * u.day).date
         obs_in_time = ((star_obs_catalogs.STARS_OBS['mp_starcat_time'] >= start)
                        & (star_obs_catalogs.STARS_OBS['mp_starcat_time'] <= stop))
         agasc_ids = sorted(star_obs_catalogs.STARS_OBS[obs_in_time]['agasc_id'])

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -324,28 +324,23 @@ def do(output_dir,
         agasc_ids = np.intersect1d(agasc_ids, star_obs_catalogs.STARS_OBS['agasc_id'])
 
     # set start/stop times and agasc_ids
-    if whole_history:
+    if whole_history or agasc_ids is not None:
         if start:
-            logger.warning('Ignoring --start argument from commant line (--whole-history)')
+            logger.warning('Ignoring --start argument from commant line')
         if stop:
-            logger.warning('Ignoring --stop argument from commant line (--whole-history)')
+            logger.warning('Ignoring --stop argument from commant line')
         start = CxoTime(star_obs_catalogs.STARS_OBS['mp_starcat_time']).min().date
         stop = CxoTime(star_obs_catalogs.STARS_OBS['mp_starcat_time']).max().date
         if agasc_ids is None:
             agasc_ids = sorted(star_obs_catalogs.STARS_OBS['agasc_id'])
-    elif agasc_ids is None:
-        if not start:
-            start = CxoTime(star_obs_catalogs.STARS_OBS['mp_starcat_time']).min().date
-        if not stop:
-            stop = CxoTime(star_obs_catalogs.STARS_OBS['mp_starcat_time']).max().date
-        obs_in_time = ((star_obs_catalogs.STARS_OBS['mp_starcat_time'] >= start)
-                       & (star_obs_catalogs.STARS_OBS['mp_starcat_time'] <= stop))
-        agasc_ids = sorted(star_obs_catalogs.STARS_OBS[obs_in_time]['agasc_id'])
     else:
         if not stop:
             stop = CxoTime.now().date
         if not start:
-            start = CxoTime(stop) - 14 * u.day
+            start = (CxoTime(stop) - 14 * u.day).date
+        obs_in_time = ((star_obs_catalogs.STARS_OBS['mp_starcat_time'] >= start)
+                       & (star_obs_catalogs.STARS_OBS['mp_starcat_time'] <= stop))
+        agasc_ids = sorted(star_obs_catalogs.STARS_OBS[obs_in_time]['agasc_id'])
 
     agasc_ids = np.unique(agasc_ids)
     stars_obs = star_obs_catalogs.STARS_OBS[
@@ -402,6 +397,7 @@ def do(output_dir,
 
     # do the processing
     logger.info(f'Will process {len(agasc_ids)} stars on {len(stars_obs)} observations')
+    logger.info(f'from {start} to {stop}')
     if dry_run:
         return
 

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -478,7 +478,7 @@ def do(output_dir,
                 report = msr.MagEstimateReport(agasc_stats, obs_stats, directory=directory)
                 report.multi_star_html(**multi_star_html_args)
                 latest = reports_dir / 'latest'
-                if latest.exists:
+                if latest.exists():
                     latest.unlink()
                 latest.symlink_to(directory)
             except Exception as e:

--- a/agasc/tests/test_obs_status.py
+++ b/agasc/tests/test_obs_status.py
@@ -196,14 +196,14 @@ def test_parse_obs_status_args_bad(monkeypatch):
     #######################
 
     status = update_obs_status._parse_obs_status_args(
-        bad_star=1, bad_star_source=2
+        bad_star_id=1, bad_star_source=2
     )
     assert status['obs'] == {}
     assert status['bad'] == {1: 2}
 
     # bad star can be a list
     status = update_obs_status._parse_obs_status_args(
-        bad_star=[1, 2], bad_star_source=3
+        bad_star_id=[1, 2], bad_star_source=3
     )
     assert status['obs'] == {}
     assert status['bad'] == {1: 3, 2: 3}
@@ -211,7 +211,7 @@ def test_parse_obs_status_args_bad(monkeypatch):
     # if you specify bad_star, you must specify bad_star_source
     with pytest.raises(RuntimeError, match=r"specify bad_star_source"):
         update_obs_status._parse_obs_status_args(
-            bad_star=1
+            bad_star_id=1
         )
 
 
@@ -297,14 +297,14 @@ def test_parse_obs_status_args(monkeypatch):
     with pytest.raises(RuntimeError, match=r"name collision"):
         _ = update_obs_status._parse_obs_status_args(
             filename=filename,
-            bad_star=23434,
+            bad_star_id=23434,
             bad_star_source=12
         )
 
     # can specify bad star in the file and in args if the source is the same.
     status = update_obs_status._parse_obs_status_args(
         filename=filename,
-        bad_star=23434,
+        bad_star_id=23434,
         bad_star_source=10
     )
     ref = copy.deepcopy(TEST_DATA[filename])
@@ -316,7 +316,7 @@ def test_parse_obs_status_args(monkeypatch):
         obs=56309,
         agasc_id=[762184312, 762184768, 762185584, 762186016],
         status=False,
-        bad_star=[1, 2],
+        bad_star_id=[1, 2],
         bad_star_source=1000
     )
     ref = update_obs_status._parse_obs_status_args(
@@ -326,7 +326,7 @@ def test_parse_obs_status_args(monkeypatch):
         obs=56309,
         agasc_id=[762184312, 762184768, 762185584, 762186016],
         status=False,
-        bad_star=[1, 2],
+        bad_star_id=[1, 2],
         bad_star_source=1000
     )
     ref['obs'].update(ref_2['obs'])


### PR DESCRIPTION
## Description

This is an omnibus PR to fix a collection of small bugs:

- Fixes #59
- Fixes #63
- Fixes #66

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing
   ```
   cp $SKA/data/agasc/* .
   export AGASC_DIR=`pwd`
   agasc-supplement-obs-status --obs-status-file status[_obs|_bad].yml 
   agasc-supplement-update --start 2021:011 --stop 2021:012 [--report]
   agasc-supplement-update # (to check --start==two weeks ago)
   ```

For functional testing, I have a file called `status.yml` which contains this:
```
bad:
  77073552: 11
  23434: 10
obs:
  - obsid: 56311
    ok: false
  - obsid: 56308
    ok: true
    agasc_id: [806750112]
  - obsid: 11849
    ok: false
    agasc_id: [1019348536, 1019350904]
    comments: just removed them
```

I also made copies of the file including only the obs/bad part. I ran the scripts mentioned. Opened the HDF5 file in ipython and checked that the dtypes were correct, that the values in obs/bad were the ones in the file, and that the mags table times correspond to what was requested.