### PR TITLE
Auto yaml

### DIFF
--- a/agasc/scripts/update_obs_status.py
+++ b/agasc/scripts/update_obs_status.py
@@ -283,7 +283,7 @@ def get_parser():
         description=__doc__,
         parents=[get_obs_status_parser()]
     )
-    parse.add_argument("--data-root",
+    parse.add_argument("--output-dir",
                        default='.',
                        type=Path,
                        help="Directory containing agasc_supplement.h5 (default='.')")
@@ -309,7 +309,7 @@ def update(args):
 
     if status['obs']:
         update_obs_table(
-            args.data_root / 'agasc_supplement.h5',
+            args.output_dir / 'agasc_supplement.h5',
             status['obs'],
             dry_run=args.dry_run
         )
@@ -318,7 +318,7 @@ def update(args):
         bad_star_ids, bad_star_source = zip(*status['bad'].items())
         add_bad_star(bad_star_ids,
                      bad_star_source,
-                     args.data_root / 'agasc_supplement.h5',
+                     args.output_dir / 'agasc_supplement.h5',
                      dry_run=args.dry_run)
     return [o[1] for o in status['obs']]
 

--- a/agasc/scripts/update_obs_status.py
+++ b/agasc/scripts/update_obs_status.py
@@ -147,7 +147,7 @@ def update_obs_table(filename, obs_status_override, dry_run=False, create=False)
         obs_status = table.Table(dtype=obs_dtype)
 
     if not dry_run:
-        obs_status.write(filename, format='hdf5', path='obs', append=True, overwrite=True)
+        obs_status.write(str(filename), format='hdf5', path='obs', append=True, overwrite=True)
         save_version(filename, 'obs')
     else:
         logger.info('dry run, not saving anything')

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -48,7 +48,8 @@ EXCEPTION_MSG = {
     2: 'No telemetry data',
     3: 'Mismatch in telemetry between aca_l0 and cheta',
     4: 'Time mismatch between cheta and level0',
-    5: 'Failed job'
+    5: 'Failed job',
+    6: 'Suspect observation'
 }
 EXCEPTION_CODES = collections.defaultdict(lambda: -1)
 EXCEPTION_CODES.update({msg: code for code, msg in EXCEPTION_MSG.items() if code > 0})
@@ -60,7 +61,7 @@ class MagStatsException(Exception):
         self.error_code = EXCEPTION_CODES[msg]
         self.msg = msg
         self.agasc_id = agasc_id
-        self.obsid = obsid
+        self.obsid = obsid[0] if type(obsid) is list and len(obsid) == 1 else obsid
         self.timeline_id = timeline_id
         for k in kwargs:
             setattr(self, k, kwargs[k])
@@ -554,8 +555,6 @@ def get_obs_stats(obs, telem=None):
                  f' OBSID {obs["agasc_id"]} at {obs["mp_starcat_time"]}')
 
     star_obs_catalogs.load()
-    if telem is None:
-        telem = get_telemetry(obs)
 
     star = get_star(obs['agasc_id'])
     dwell = star_obs_catalogs.DWELLS_NP[star_obs_catalogs.DWELLS_MAP[obs['mp_starcat_time']]]
@@ -576,10 +575,55 @@ def get_obs_stats(obs, telem=None):
                   'row': obs['row'],
                   'col': obs['col'],
                   })
-    stats.update(calc_obs_stats(telem))
-    logger.debug(f'    slot={stats["slot"]}, f_ok={stats["f_ok"]:.3f}, '
-                 f'f_track={stats["f_track"]:.3f}, f_dr3={stats["f_dr3"]:.3f},'
-                 f' mag={stats["mag_obs"]:.2f}')
+
+    # other default values
+    stats.update({
+        'mag_img': np.inf,
+        'mag_obs': np.inf,
+        'mag_obs_err': np.inf,
+        'aoacmag_mean': np.inf,
+        'aoacmag_err': np.inf,
+        'aoacmag_q25': np.inf,
+        'aoacmag_median': np.inf,
+        'aoacmag_q75': np.inf,
+        'counts_img': np.inf,
+        'counts_dark': np.inf,
+        'f_kalman': 0.,
+        'f_track': 0.,
+        'f_dr5': 0.,
+        'f_dr3': 0.,
+        'f_ok': 0.,
+        'q25': np.inf,
+        'median': np.inf,
+        'q75': np.inf,
+        'mean': np.inf,
+        'mean_err': np.inf,
+        'std': np.inf,
+        'skew': np.inf,
+        'kurt': np.inf,
+        't_mean': np.inf,
+        't_mean_err': np.inf,
+        't_std': np.inf,
+        't_skew': np.inf,
+        't_kurt': np.inf,
+        'n': 0,
+        'n_ok': 0,
+        'outliers': -1,
+        'lf_variability_100s': np.inf,
+        'lf_variability_500s': np.inf,
+        'lf_variability_1000s': np.inf,
+        'tempccd': np.nan,
+        'dr_star': np.inf,
+    })
+
+    if telem is None:
+        telem = get_telemetry(obs)
+
+    if len(telem) > 0:
+        stats.update(calc_obs_stats(telem))
+        logger.debug(f'    slot={stats["slot"]}, f_ok={stats["f_ok"]:.3f}, '
+                     f'f_track={stats["f_track"]:.3f}, f_dr3={stats["f_dr3"]:.3f},'
+                     f' mag={stats["mag_obs"]:.2f}')
     return stats
 
 
@@ -618,41 +662,13 @@ def calc_obs_stats(telem):
         dr_star = np.inf
 
     stats = {
-        'mag_img': np.inf,
-        'mag_obs': np.inf,
-        'mag_obs_err': np.inf,
-        'aoacmag_mean': np.inf,
-        'aoacmag_err': np.inf,
-        'aoacmag_q25': np.inf,
-        'aoacmag_median': np.inf,
-        'aoacmag_q75': np.inf,
-        'counts_img': np.inf,
-        'counts_dark': np.inf,
         'f_kalman': f_kalman,
         'f_track': f_track,
         'f_dr5': f_5,
         'f_dr3': f_3,
         'f_ok': f_ok,
-        'q25': np.inf,
-        'median': np.inf,
-        'q75': np.inf,
-        'mean': np.inf,
-        'mean_err': np.inf,
-        'std': np.inf,
-        'skew': np.inf,
-        'kurt': np.inf,
-        't_mean': np.inf,
-        't_mean_err': np.inf,
-        't_std': np.inf,
-        't_skew': np.inf,
-        't_kurt': np.inf,
         'n': len(telem['AOACMAG']),
         'n_ok': np.sum(ok),
-        'outliers': -1,
-        'lf_variability_100s': np.inf,
-        'lf_variability_500s': np.inf,
-        'lf_variability_1000s': np.inf,
-        'tempccd': np.nan,
         'dr_star': dr_star,
     }
     if stats['n_ok'] < 10:
@@ -736,84 +752,23 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
     if len(star_obs) > 1:
         star_obs = star_obs.loc['mp_starcat_time', sorted(star_obs['mp_starcat_time'])]
 
-    failures = []
-    all_telem = []
-    stats = []
-    last_obs_time = 0
-    for i, o in enumerate(star_obs):
-        try:
-            telem = Table(get_telemetry(o))
-            all_telem.append(telem)
-            stats.append(get_obs_stats(o, telem={k: telem[k] for k in telem.colnames}))
-            last_obs_time = CxoTime(o['mp_starcat_time']).cxcsec
-        except MagStatsException as e:
-            logger.debug(f'  Error in get_agasc_id_stats({agasc_id=}, obsid={o["obsid"]}): {e}')
-            failures.append(dict(e))
-
-    if len(all_telem) == 0:
-        logger.debug(f'  Error in get_agasc_id_stats({agasc_id=}): No telemetry data')
-        raise MagStatsException('No telemetry data', agasc_id=agasc_id)
-
-    stats = Table(stats)
-    n_obsids = len(star_obs)
-
-    stats['w'] = np.nan
-    stats['mean_corrected'] = np.nan
-    stats['weighted_mean'] = np.nan
-    stats['obs_ok'] = (
-        (stats['n'] > 10)
-        & (stats['f_track'] > 0.3)
-        & (stats['lf_variability_100s'] < 1)
-    )
-    stats['comments'] = np.zeros(len(stats), dtype='<U100')
-    if obs_status_override:
-        logger.debug('  checking obs status...')
-        for i, (oi, ai) in enumerate(stats[['obsid', 'agasc_id']]):
-            if (oi, ai) in obs_status_override:
-                stats[i]['obs_ok'] = (obs_status_override[(oi, ai)]['status'] == 0)
-                stats[i]['comments'] = obs_status_override[(oi, ai)]['comments']
-                logger.debug(f'  overriding status for (AGASC ID {ai}, OBSID {oi}): '
-                             f'{stats[i]["obs_ok"]}, {stats[i]["comments"]}')
-    else:
-        logger.debug('  no obs status info')
-
-    logger.debug('  identifying outlying observations...')
-    for s, t in zip(stats, all_telem):
-        t['obs_ok'] = np.ones_like(t['ok'], dtype=bool) * s['obs_ok']
-        logger.debug('  identifying outlying observations '
-                     f'(OBSID={s["obsid"]}, mp_starcat_time={s["mp_starcat_time"]})')
-        t['obs_outlier'] = np.zeros_like(t['ok'])
-        if np.any(t['ok']) and s['f_track'] > 0 and s['obs_ok']:
-            iqr = s['q75'] - s['q25']
-            t['obs_outlier'] = (
-                t['ok']
-                & (iqr > 0)
-                & ((t['mags'] < s['q25'] - 1.5 * iqr) | (t['mags'] > s['q75'] + 1.5 * iqr))
-            )
-    all_telem = vstack([Table(t) for t in all_telem])
-
-    mags = all_telem['mags']
-    ok = all_telem['ok'] & all_telem['obs_ok']
-
-    f_ok = np.sum(ok) / len(ok)
-
-    star = get_star(agasc_id, date=all_telem['times'][0])
+    # this is the default result, if nothing gets calculated
     result = {
-        'last_obs_time': last_obs_time,
+        'last_obs_time': 0,
         'agasc_id': agasc_id,
-        'mag_aca': star['MAG_ACA'],
-        'mag_aca_err': star['MAG_ACA_ERR'] / 100,
+        'mag_aca': np.nan,
+        'mag_aca_err': np.nan,
         'mag_obs': 0.,
-        'mag_obs_err': min_mag_obs_err,
+        'mag_obs_err': np.nan,
         'mag_obs_std': 0.,
-        'color': star['COLOR1'],
-        'n_obsids': n_obsids,
-        'n_obsids_fail': len(failures),
-        'n_obsids_ok': np.sum(stats['obs_ok']),
-        'n_no_track': np.sum(stats['f_ok'] < 0.3),
-        'n': len(ok),
-        'n_ok': np.sum(ok),
-        'f_ok': f_ok,
+        'color': np.nan,
+        'n_obsids': 0,
+        'n_obsids_fail': 0,
+        'n_obsids_ok': 0,
+        'n_no_track': 0,
+        'n': 0,
+        'n_ok': 0,
+        'f_ok': 0.,
         'median': 0,
         'sigma_minus': 0,
         'sigma_plus': 0,
@@ -852,6 +807,123 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
             f'sigma_minus_dr{dr}': 0,
             f'sigma_plus_dr{dr}': 0,
         })
+
+    n_obsids = len(star_obs)
+
+    # exclude star_obs that are in obs_status_override with status != 0
+    excluded_obs = np.array([((oi, ai) in obs_status_override
+                             and obs_status_override[(oi, ai)]['status'] != 0)
+                             for oi, ai in star_obs[['obsid', 'agasc_id']]])
+    if np.any(excluded_obs):
+        logger.debug('  Excluding observations flagged in obs-status table: '
+                     f'{list(star_obs[excluded_obs]["obsid"])}')
+
+    failures = []
+    all_telem = []
+    stats = []
+    last_obs_time = 0
+    for i, o in enumerate(star_obs):
+        oi, ai = o['obsid', 'agasc_id']
+        comment = ''
+        if (oi, ai) in obs_status_override:
+            status = obs_status_override[(oi, ai)]
+            print(status)
+            logger.debug(f'  overriding status for (AGASC ID {ai}, OBSID {oi}): '
+                         f'{status["status"]}, {status["comments"]}')
+            comment = status['comments']
+        try:
+            telem = Table(get_telemetry(o))
+            obs_stat = get_obs_stats(o, telem={k: telem[k] for k in telem.colnames})
+            last_obs_time = CxoTime(o['mp_starcat_time']).cxcsec
+            obs_stat.update({
+                'obs_ok': (
+                    ~excluded_obs[i]
+                    & (obs_stat['n'] > 10)
+                    & (obs_stat['f_track'] > 0.3)
+                    & (obs_stat['lf_variability_100s'] < 1)
+                ),
+                'obs_suspect': False,
+                'obs_fail': False,
+                'comments': comment
+            })
+            all_telem.append(telem)
+            stats.append(obs_stat)
+
+            if not obs_stat['obs_ok'] and not excluded_obs[i]:
+                obs_stat['obs_suspect'] = True
+                failures.append(
+                    dict(MagStatsException(msg='Suspect observation', agasc_id=ai, obsid=oi)))
+        except MagStatsException as e:
+            # this except branch deals with exceptions thrown by get_telemetry
+            all_telem.append(None)
+            # length-zero telemetry short-circuits any new call to get_telemetry
+            obs_stat = get_obs_stats(o, telem=[])
+            obs_stat.update({
+                'obs_ok': False,
+                'obs_suspect': False,
+                'obs_fail': True,
+                'comments': comment if excluded_obs[i] else f'Error: {e.msg}.'
+            })
+            stats.append(obs_stat)
+            if not excluded_obs[i]:
+                logger.debug(f'  Error in get_agasc_id_stats({agasc_id=}, obsid={o["obsid"]}): {e}')
+                failures.append(dict(e))
+
+    result['n_obsids_fail'] = len(failures)
+
+    stats = Table(stats)
+    stats['w'] = np.nan
+    stats['mean_corrected'] = np.nan
+    stats['weighted_mean'] = np.nan
+
+    if not np.any(~excluded_obs):
+        logger.debug('  Skipping star in get_agasc_id_stats({agasc_id=}).'
+                     ' All observations are flagged as not good.')
+        return result, stats, failures
+
+    if len(all_telem) - len(failures) <= 0:
+        logger.debug(f'  Error in get_agasc_id_stats({agasc_id=}): No telemetry data')
+        return result, stats, failures
+
+    excluded_obs += np.array([t is None for t in all_telem])
+
+    logger.debug('  identifying outlying observations...')
+    for i, (s, t) in enumerate(zip(stats, all_telem)):
+        if excluded_obs[i]:
+            continue
+        t['obs_ok'] = np.ones_like(t['ok'], dtype=bool) * s['obs_ok']
+        logger.debug('  identifying outlying observations '
+                     f'(OBSID={s["obsid"]}, mp_starcat_time={s["mp_starcat_time"]})')
+        t['obs_outlier'] = np.zeros_like(t['ok'])
+        if np.any(t['ok']) and s['f_track'] > 0 and s['obs_ok']:
+            iqr = s['q75'] - s['q25']
+            t['obs_outlier'] = (
+                t['ok']
+                & (iqr > 0)
+                & ((t['mags'] < s['q25'] - 1.5 * iqr) | (t['mags'] > s['q75'] + 1.5 * iqr))
+            )
+    all_telem = vstack([Table(t) for i, t in enumerate(all_telem) if not excluded_obs[i]])
+
+    mags = all_telem['mags']
+    ok = all_telem['ok'] & all_telem['obs_ok']
+
+    f_ok = np.sum(ok) / len(ok)
+
+    star = get_star(agasc_id, date=all_telem['times'][0])
+    result.update({
+        'last_obs_time': last_obs_time,
+        'mag_aca': star['MAG_ACA'],
+        'mag_aca_err': star['MAG_ACA_ERR'] / 100,
+        'mag_obs_err': min_mag_obs_err,
+        'color': star['COLOR1'],
+        'n_obsids': n_obsids,
+        'n_obsids_fail': len(failures),
+        'n_obsids_ok': np.sum(stats['obs_ok']),
+        'n_no_track': np.sum((~stats['obs_ok'])) + np.sum(stats['f_ok'][stats['obs_ok']] < 0.3),
+        'n': len(ok),
+        'n_ok': np.sum(ok),
+        'f_ok': f_ok,
+    })
 
     if result['n_ok'] < 10:
         return result, stats, failures

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -828,7 +828,6 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
         comment = ''
         if (oi, ai) in obs_status_override:
             status = obs_status_override[(oi, ai)]
-            print(status)
             logger.debug(f'  overriding status for (AGASC ID {ai}, OBSID {oi}): '
                          f'{status["status"]}, {status["comments"]}')
             comment = status['comments']
@@ -875,11 +874,12 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
     stats['mean_corrected'] = np.nan
     stats['weighted_mean'] = np.nan
 
-    result['n_obsids_fail'] = np.sum(stats['obs_fail'])
+    result['n_obsids_fail'] = len(failures)
     result['n_obsids_suspect'] = np.sum(stats['obs_suspect'])
+    result['n_obsids'] = n_obsids
 
     if not np.any(~excluded_obs):
-        logger.debug('  Skipping star in get_agasc_id_stats({agasc_id=}).'
+        logger.debug(f'  Skipping star in get_agasc_id_stats({agasc_id=}).'
                      ' All observations are flagged as not good.')
         return result, stats, failures
 
@@ -918,7 +918,6 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
         'mag_aca_err': star['MAG_ACA_ERR'] / 100,
         'mag_obs_err': min_mag_obs_err,
         'color': star['COLOR1'],
-        'n_obsids': n_obsids,
         'n_obsids_ok': np.sum(stats['obs_ok']),
         'n_no_track': np.sum((~stats['obs_ok'])) + np.sum(stats['f_ok'][stats['obs_ok']] < 0.3),
         'n': len(ok),

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -764,6 +764,7 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
         'color': np.nan,
         'n_obsids': 0,
         'n_obsids_fail': 0,
+        'n_obsids_suspect': 0,
         'n_obsids_ok': 0,
         'n_no_track': 0,
         'n': 0,
@@ -869,12 +870,13 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
                 logger.debug(f'  Error in get_agasc_id_stats({agasc_id=}, obsid={o["obsid"]}): {e}')
                 failures.append(dict(e))
 
-    result['n_obsids_fail'] = len(failures)
-
     stats = Table(stats)
     stats['w'] = np.nan
     stats['mean_corrected'] = np.nan
     stats['weighted_mean'] = np.nan
+
+    result['n_obsids_fail'] = np.sum(stats['obs_fail'])
+    result['n_obsids_suspect'] = np.sum(stats['obs_suspect'])
 
     if not np.any(~excluded_obs):
         logger.debug('  Skipping star in get_agasc_id_stats({agasc_id=}).'
@@ -917,7 +919,6 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
         'mag_obs_err': min_mag_obs_err,
         'color': star['COLOR1'],
         'n_obsids': n_obsids,
-        'n_obsids_fail': len(failures),
         'n_obsids_ok': np.sum(stats['obs_ok']),
         'n_no_track': np.sum((~stats['obs_ok'])) + np.sum(stats['f_ok'][stats['obs_ok']] < 0.3),
         'n': len(ok),

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -2,6 +2,8 @@
 Functions to estimate observed ACA magnitudes
 """
 
+import sys
+import traceback
 import logging
 import collections
 
@@ -410,16 +412,14 @@ def get_telemetry_by_agasc_id(agasc_id, obsid=None, ignore_exceptions=False):
             t['agasc_id'] = agasc_id
             telem.append(t)
         except Exception:
-            import sys
-            import traceback
-            logger.info(f'{agasc_id=}, obsid={o["obsid"]} failed')
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            trace = traceback.extract_tb(exc_traceback)
-            logger.info(f'{exc_type.__name__} {exc_value}')
-            for step in trace:
-                logger.info(f'  in {step.filename}:{step.lineno}/{step.name}:')
-                logger.info(f'    {step.line}')
             if not ignore_exceptions:
+                logger.info(f'{agasc_id=}, obsid={o["obsid"]} failed')
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                trace = traceback.extract_tb(exc_traceback)
+                logger.info(f'{exc_type.__name__} {exc_value}')
+                for step in trace:
+                    logger.info(f'  in {step.filename}:{step.lineno}/{step.name}:')
+                    logger.info(f'    {step.line}')
                 raise
     return vstack(telem)
 

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -70,7 +70,7 @@ class MagEstimateReport:
         s = self.agasc_stats[self.agasc_stats['agasc_id'] == agasc_id][0]
         s = {k: s[k] for k in s.colnames}
         s['n_obs_bad'] = \
-            s['n_obsids'] - s['n_obsids_ok'] - s['n_obsids_fail'] - s['n_obsids_suspect']
+            s['n_obsids'] - s['n_obsids_ok']
         s['last_obs'] = ':'.join(o[-1]['mp_starcat_time'].split(':')[:4])
 
         # OBSIDs can be repeated
@@ -162,8 +162,7 @@ class MagEstimateReport:
 
         # add some extra fields
         if len(agasc_stats):
-            agasc_stats['n_obs_bad_fail'] = \
-                agasc_stats['n_obsids_fail'] + agasc_stats['n_obsids_suspect']
+            agasc_stats['n_obs_bad_fail'] = agasc_stats['n_obsids_fail']
             agasc_stats['n_obs_bad'] = agasc_stats['n_obsids'] - agasc_stats['n_obsids_ok']
             agasc_stats['flag'] = '          '
             agasc_stats['flag'][:] = ''
@@ -187,7 +186,7 @@ class MagEstimateReport:
 
         tooltips = {
             'warning': 'At least one bad observation',
-            'danger': 'At least one suspect or failed observation'
+            'danger': 'At least failed observation'
         }
 
         # make all individual star reports

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -69,7 +69,8 @@ class MagEstimateReport:
         o.sort(keys=['mp_starcat_time'])
         s = self.agasc_stats[self.agasc_stats['agasc_id'] == agasc_id][0]
         s = {k: s[k] for k in s.colnames}
-        s['n_obs_bad'] = s['n_obsids'] - s['n_obsids_ok'] - s['n_obsids_fail']
+        s['n_obs_bad'] = \
+            s['n_obsids'] - s['n_obsids_ok'] - s['n_obsids_fail'] - s['n_obsids_suspect']
         s['last_obs'] = ':'.join(o[-1]['mp_starcat_time'].split(':')[:4])
 
         # OBSIDs can be repeated
@@ -161,7 +162,8 @@ class MagEstimateReport:
 
         # add some extra fields
         if len(agasc_stats):
-            agasc_stats['n_obs_bad_fail'] = agasc_stats['n_obsids_fail']
+            agasc_stats['n_obs_bad_fail'] = \
+                agasc_stats['n_obsids_fail'] + agasc_stats['n_obsids_suspect']
             agasc_stats['n_obs_bad'] = agasc_stats['n_obsids'] - agasc_stats['n_obsids_ok']
             agasc_stats['flag'] = '          '
             agasc_stats['flag'][:] = ''

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -1,6 +1,8 @@
 import platform
 import getpass
 import logging
+import errno
+import os
 from subprocess import Popen, PIPE
 from pathlib import Path
 from email.mime.text import MIMEText
@@ -23,9 +25,27 @@ logger = logging.getLogger('agasc.supplement')
 
 
 class MagEstimateReport:
-    def __init__(self, agasc_stats, obs_stats, directory='./mag_estimates_reports'):
-        self.agasc_stats = agasc_stats
-        self.obs_stats = obs_stats
+    def __init__(self,
+                 agasc_stats='mag_stats_agasc.fits',
+                 obs_stats='mag_stats_obsid.fits',
+                 directory='./mag_estimates_reports'):
+
+        if type(agasc_stats) is table.Table:
+            self.agasc_stats = agasc_stats
+        else:
+            if not Path(agasc_stats).exists:
+                raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), agasc_stats)
+            self.agasc_stats = table.Table.read(agasc_stats)
+            self.agasc_stats.convert_bytestring_to_unicode()
+
+        if type(obs_stats) is table.Table:
+            self.obs_stats = obs_stats
+        else:
+            if not Path(obs_stats).exists:
+                raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), obs_stats)
+            self.obs_stats = table.Table.read(obs_stats)
+            self.obs_stats.convert_bytestring_to_unicode()
+
         self.directory = Path(directory)
 
     def single_star_html(self, agasc_id, directory,

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -269,11 +269,14 @@ class MagEstimateReport:
                 logger.debug(f'Error making plot: {e}')
                 telem = []
 
-        if len(telem) == 0:
+        if len(telem) == 0 or (arg_obsid is not None and np.sum(telem['obsid'] == arg_obsid) == 0):
+            msg = 'No Telemetry'
+            if arg_obsid is not None:
+                msg += f' for OBSID {arg_obsid}'
             ax.text(
                 np.mean(ax.get_xlim()),
                 np.mean(ax.get_ylim()),
-                'No Telemetry',
+                msg,
                 horizontalalignment='center',
                 verticalalignment='center')
             return
@@ -501,7 +504,7 @@ class MagEstimateReport:
         if ax is None:
             ax = plt.gca()
 
-        if len(telemetry) == 0:
+        if len(telemetry) > 0:
             timeline = telemetry[['times', 'mags', 'obsid', 'obs_ok', 'dr', 'AOACFCT',
                                   'AOACASEQ', 'AOACIIR', 'AOACISP', 'AOPCADMD',
                                   ]]
@@ -546,6 +549,9 @@ class MagEstimateReport:
             ]
 
         if obsid:
+            for i, (l, o) in enumerate(flags):
+                flags[i] = (l, o[timeline['obsid'] == obsid])
+            all_ok = all_ok[timeline['obsid'] == obsid]
             timeline = timeline[timeline['obsid'] == obsid]
 
         obsids = np.unique(timeline['obsid'])

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -160,13 +160,13 @@ class MagEstimateReport:
 
         # add some extra fields
         if len(agasc_stats):
-            agasc_stats['n_obs_bad_new'] = agasc_stats['n_obsids_fail']
+            agasc_stats['n_obs_bad_fail'] = agasc_stats['n_obsids_fail']
             agasc_stats['n_obs_bad'] = agasc_stats['n_obsids'] - agasc_stats['n_obsids_ok']
             agasc_stats['flag'] = '          '
             agasc_stats['flag'][:] = ''
             agasc_stats['flag'][(agasc_stats['n_obs_bad'] > 0)
                                 | (agasc_stats['n_obsids'] == 0)] = 'warning'
-            agasc_stats['flag'][agasc_stats['n_obs_bad_new'] > 0] = 'danger'
+            agasc_stats['flag'][agasc_stats['n_obs_bad_fail'] > 0] = 'danger'
             agasc_stats['delta'] = (agasc_stats['t_mean_dr3'] - agasc_stats['mag_aca'])
             agasc_stats['sigma'] = ((agasc_stats['t_mean_dr3'] - agasc_stats['mag_aca'])
                                     / agasc_stats['mag_aca_err'])
@@ -184,7 +184,7 @@ class MagEstimateReport:
 
         tooltips = {
             'warning': 'At least one bad observation',
-            'danger': 'At least one new bad observation'
+            'danger': 'At least one suspect or failed observation'
         }
 
         # make all individual star reports

--- a/agasc/supplement/magnitudes/templates/email_report.txt
+++ b/agasc/supplement/magnitudes/templates/email_report.txt
@@ -1,0 +1,7 @@
+Warning in magnitude estimates at {{ date }}.
+
+There were {{ bad_obs | length }} suspicious observation{% if bad_obs |length != 1 %}s{% endif %}
+in magnitude estimates:
+{% for s in bad_obs %}
+- {{ "% 6d" | format(s.obsid) }}: time={{ s.mp_starcat_time }}, n={{ s.n }}, n_ok={{ s.n_ok }}, outliers={{ s.outliers }}, f_track={{ "%.1f" | format(100*s.f_track) }}%
+{% endfor %}

--- a/agasc/supplement/magnitudes/templates/run_report.html
+++ b/agasc/supplement/magnitudes/templates/run_report.html
@@ -1,0 +1,171 @@
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="stylesheet"
+          href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
+          integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
+          crossorigin="anonymous">
+  </head>
+  <body>
+
+    <div class="container">
+    {% if nav_links %}
+    <nav aria-label="Page navigation example">
+      <ul class="pagination">
+        <li class="page-item"><a class="page-link" href='{{ nav_links.previous}}'>
+          <span aria-hidden="true">&laquo;</span>
+          <span class="sr-only">Previous</span>
+        </a></li>
+        <li class="page-item"><a class="page-link" href='{{ nav_links.up}}'>
+          <!--span aria-hidden="true">&#8896;</span-->
+          <!--span aria-hidden="true">&Hat;</span-->
+          <!--span aria-hidden="true">&#8962;</span-->
+          <span aria-hidden="true">&#127968;</span>
+          <span class="sr-only">Up</span>
+        </a></li>
+        <li class="page-item"><a class="page-link" href='{{ nav_links.next}}'>
+          <span aria-hidden="true">&raquo;</span>
+          <span class="sr-only">Next</span>
+        </a></li>
+      </ul>
+    </nav>
+
+    {% endif %}
+    <h1> ACA Magnitude Statistics </h1>
+    <h2> {{ info.report_date }} Update Report </h2>
+    <table class="table table-sm">
+      <tr>
+        <td style="width: 50%"> Time range </td>
+        <td style="width: 50%"> {{ info.tstart }} &ndash; {{ info.tstop }} </td>
+      </tr>
+      {%- for section in sections %}
+      <tr>
+        <td> <a href="#{{ section.id }}"> {{ section.title }} </a> </td>
+        <td> {{ section.stars | length }} </td>
+      </tr>
+      {%- endfor %}
+      <tr>
+        <td> {% if failures -%} <a href="#failures"> Failures </a>
+             {%- else -%} Failures {%- endif %} </td>
+        <td> {{ failures | length }} </td>
+      </tr>
+    </table>
+
+    {%- for section in sections %}
+    <a name="{{ section.id }}"> </a>
+    <h3> {{ section.title }} </h3>
+    <table class="table table-hover">
+      <tr>
+      <tr>
+        <th data-toggle="tooltip" data-placement="top" title="ID in AGASC"> AGASC ID </th>
+        <th data-toggle="tooltip" data-placement="top" title="Last time the star was observed"> Last Obs </th>
+        <th data-toggle="tooltip" data-placement="top" title="Number of times the star has been observed"> n<sub>obs</sub> </th>
+        <th data-toggle="tooltip" data-html="true" data-placement="top" title="Observations not included in calculation <br/> n &gt; 10 <br/>f_ok &gt; 0.3 <br/> &langle; &delta; <sub>mag</sub> &rangle; <sub>100s</sub>  < 1"> n<sub>bad</sub> </th>
+        <th data-toggle="tooltip" data-html="true" data-placement="top" title="Suspect or failed observations (not included in calculation) <br/> n &gt; 10 <br/>f_ok &gt; 0.3 <br/> &langle; &delta; <sub>mag</sub> &rangle; <sub>100s</sub>  < 1"> n<sub>fail</sub> </th>
+        <th data-toggle="tooltip" data-placement="top" data-html="true" title="tracking time as fraction of total time: <br/> AOACASEQ == 'KALM' <br/> AOACIIR == 'OK' <br/> AOACISP == 'OK' <br/> AOPCADMD == 'NPNT' <br/> AOACFCT == 'TRAK' <br/> OBS_OK)"> f<sub>track</sub> </th>
+        <th data-toggle="tooltip" data-placement="top" title="Fraction of the tracking time within 5 arcsec of target"> f<sub>5 arcsec</sub> </th>
+        <th data-toggle="tooltip" data-placement="top" title="Magnitude in AGASC"> mag<sub>catalog</sub> </th>
+        <th data-toggle="tooltip" data-placement="top" title="Magnitude observed"> mag<sub>obs</sub> </th>
+        <th data-toggle="tooltip" data-placement="top" title="Difference between observed and catalog magnitudes"> &delta;<sub>mag cat</sub> </th>
+        <th data-toggle="tooltip" data-placement="top" title="Difference between observed and catalog magnitudes, divided by catalog magnitude error"> &delta;<sub>mag</sub>/&sigma;<sub>mag</sub> </th>
+        <th data-toggle="tooltip" data-placement="top" title="Variation in observed magnitude from the last version of AGASC supplement"> &delta;<sub>mag</sub> </th>
+        <th data-toggle="tooltip" data-placement="top" title="Variation in observed magnitude standard deviation from the last version of AGASC supplement"> &delta;<sub>&sigma;</sub> </th>
+        <th data-toggle="tooltip" data-placement="top" title="Color in AGASC"> color </th>
+      </tr>
+      {%- for star in section.stars %}
+      <tr {% if star.flag != '' -%}
+          class="table-{{ star.flag }}"
+          data-toggle="tooltip"
+          data-placement="top" title="{{ tooltips[star.flag] }}"
+        {%- endif -%}
+        >
+        <td>
+        {%- if star.agasc_id in star_reports -%}
+          <a href="{{ star_reports[star.agasc_id] }}/index.html"> {{ star.agasc_id }} </a>
+        {%- else -%}
+          {{ star.agasc_id }}
+        {%- endif -%}
+        </td>
+        <td> {{ star.last_obs[:8] }} </td>
+        <td> {{ star.n_obsids }}  </td>
+        <td> {%- if star.n_obs_bad > 0 %} {{ star.n_obs_bad }} {% endif %} </td>
+        <td> {%- if star.n_obs_bad_fail > 0 %} {{ star.n_obs_bad_fail }} {% endif %} </td>
+        <td> {{ "%.1f" | format(100*star.f_ok) }}%  </td>
+        <td> {{ "%.1f" | format(100*star.f_dr5) }}% </td>
+        <td {% if star.selected_mag_aca_err -%}
+              class="table-info"
+              data-toggle="tooltip" data-placement="top"
+              title="Large magnitude error in catalog"
+            {%- endif %}>
+          {{ "%.2f" | format(star.mag_aca) }} &#177; {{ "%.2f" | format(star.mag_aca_err) }}
+        </td>
+        <td>
+          {{ "%.2f" | format(star.mag_obs) }} &#177; {{ "%.2f" | format(star.mag_obs_err) }}
+        </td>
+        <td {%- if star.selected_atol %}
+              class="table-info"
+              data-toggle="tooltip" data-placement="top"
+              title="Large absolute difference between observed and catalogue magnitudes"
+            {% endif %}> {{ "%.2f" | format(star.delta) }}  </td>
+        <td {%- if star.selected_rtol %}
+              class="table-info"
+              data-toggle="tooltip" data-placement="top"
+              title="Large relative difference between observed and catalogue magnitudes"
+            {% endif %}> {{ "%.2f" | format(star.sigma) }}  </td>
+        <td>
+          {%- if star.new %} &ndash; {% else -%}
+          {{ "%.2f" | format(star.update_mag_aca) }}{% endif -%}
+        </td>
+        <td>
+          {%- if star.new %} &ndash; {% else -%}
+          {{ "%.2f" | format(star.update_mag_aca_err) }}{% endif -%}
+        </td>
+        <td {%- if star.selected_color %}
+              class="table-info"
+              data-toggle="tooltip" data-placement="top"
+              title="Color==1.5 or color==0.7 in catalog"
+            {% endif %}> {{ "%.2f" | format(star.color) }}  </td>
+      </tr>
+      {%- endfor %}
+    <table>
+    {%- endfor %}
+
+    <a name="failures"> </a>
+    {%- if failures %}
+    <h3> Failures </h3>
+    <table class="table table-hover">
+      <tr>
+        <th> AGASC ID </th>
+        <th> OBSID </th>
+        <th> Message </th>
+      </tr>
+      {%- for failure in failures %}
+      <tr>
+        <td> {%- if failure.agasc_id in star_reports -%}
+          <a href="{{ star_reports[failure.agasc_id] }}/index.html"> {{ failure.agasc_id }} </a>
+          {%- else -%} {{ failure.agasc_id }} {%- endif -%} </td>
+        <td> {{ failure.obsid }} </td>
+        <td> {{ failure.msg }} </td>
+      </tr>
+      {%- endfor %}
+    </table>
+    {% endif %}
+    </div>
+
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+    integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+    crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"
+    integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
+    crossorigin="anonymous"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
+    integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
+    crossorigin="anonymous"></script>
+
+  <script type="text/javascript">
+    $(document).ready(function() {
+    $("body").tooltip({ selector: '[data-toggle=tooltip]' });
+});
+  </script>
+</html>

--- a/agasc/supplement/magnitudes/templates/star_report.html
+++ b/agasc/supplement/magnitudes/templates/star_report.html
@@ -1,0 +1,114 @@
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="stylesheet"
+          href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
+          integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
+          crossorigin="anonymous">
+  </head>
+  <body>
+
+    <div class="container">
+      <h1> AGASC ID {{ agasc_stats.agasc_id }} </h1>
+      <h3> Info </h3>
+      <div class="row">
+        <div class="col-md">
+          <table class="table table-bordered table-sm">
+            <tr>
+              <td style="width: 30%"> Last Obs. </td>
+              <td style="width: 30%"> {{ agasc_stats.last_obs }} </td>
+            </tr>
+            <tr>
+              <td style="width: 30%"> mag<sub>catalog</sub> </td>
+              <td style="width: 30%">
+                {{ "%.2f" | format(agasc_stats.mag_aca) }} &#177; {{ "%.2f" | format(agasc_stats.mag_aca_err) }}
+              </td>
+            </tr>
+            <tr>
+              <td> mag<sub>3 arcsec </sub> </td>
+              <td>
+                {{ "%.2f" | format(agasc_stats.t_mean_dr3) }} &#177; {{ "%.2f" | format(agasc_stats.t_std_dr3) }}
+              </td>
+            </tr>
+            <tr>
+              <td> mag<sub>5 arcsec </sub> </td>
+              <td>
+                {{ "%.2f" | format(agasc_stats.t_mean_dr5) }} &#177; {{ "%.2f" | format(agasc_stats.t_std_dr5) }}
+              </td>
+            </tr>
+          </table>
+        </div>
+        <div class="col-md">
+          <table class="table table-bordered table-sm">
+            <tr>
+              <td> N<sub>obs</sub> </td>
+              <td>
+                {{ agasc_stats.n_obsids }} <span{%- if agasc_stats.n_obs_bad %} style="color:red;"{% endif -%}> ({{ agasc_stats.n_obs_bad }} bad) <span>
+              </td>
+            </tr>
+            <tr>
+              <td> f<sub>ok</sub> </td>
+              <td> {{ "%.1f" | format(100*agasc_stats.f_ok) }}%  </td>
+            </tr>
+            <tr>
+              <td> f<sub>3 arcsec</sub> </td>
+              <td> {{ "%.1f" | format(100*agasc_stats.f_dr3) }}% </td>
+            </tr>
+            <tr>
+              <td> f<sub>5 arcsec</sub> </td>
+              <td> {{ "%.1f" | format(100*agasc_stats.f_dr5) }}% </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  
+  
+      <h3> Timeline </h3>
+      <img src="mag_stats.png" width="100%"/>
+  
+      <h3> Observation Info </h3>
+      <table  class="table table-hover">
+        <tr>
+          <th data-toggle="tooltip" data-placement="top" title="OBSID"> OBSID </th>
+          <th data-toggle="tooltip" data-placement="top" title="MP starcat time"> Time </th>
+          <th data-toggle="tooltip" data-placement="top" title="Pixel row"> Row </th>
+          <th data-toggle="tooltip" data-placement="top" title="Pixel column"> Col </th>
+          <!-- th data-toggle="tooltip" data-placement="top" data-html="true" title="Observation is considered in the calculation <br/> n &gt; 10 <br/>f_ok &gt; 0.3 <br/> &langle; &delta; <sub>mag</sub> &rangle; <sub>100s</sub>  < 1"> OK </th -->
+          <th data-toggle="tooltip" data-placement="top" data-html="true" title="Number of time samples"> N </th>
+          <th data-toggle="tooltip" data-placement="top" data-html="true" title="Number of time samples considered as 'tracking' <br/> AOACASEQ == 'KALM' <br/> AOACIIR == 'OK' <br/> AOACISP == 'OK' <br/> AOPCADMD == 'NPNT' <br/> AOACFCT == 'TRAK' <br/> OBS_OK)"> N<sub>ok</sub> </th>
+          <th data-toggle="tooltip" data-placement="top" data-html="true" title="Number of outlying samples"> N<sub>out</sub> </th>
+          <th data-toggle="tooltip" data-placement="top" data-html="true" title="Tracking time as a fraction of the total time <br/> AOACASEQ == 'KALM' <br/> AOACIIR == 'OK' <br/> AOACISP == 'OK' <br/> AOPCADMD == 'NPNT' <br/> AOACFCT == 'TRAK' <br/> OBS_OK)"> f<sub>track</sub> </th>
+          <th data-toggle="tooltip" data-placement="top" data-html="true" title="Fraction of tracking time within 3 arcsec of target"> f<sub>dr3</sub> </th>
+          <th data-toggle="tooltip" data-placement="top" data-html="true" title="Fraction of tracking time within 5 arcsec of target"> f<sub>dr5</sub> </th>
+          <th data-toggle="tooltip" data-placement="top" data-html="true" title="Time where slot is tracking and target within 3 arcsec <br/> as fraction of total time"> f<sub>ok</sub> </th>
+          <th data-toggle="tooltip" data-placement="top" data-html="true" title="100-second Rolling mean of mag - &langle; mag &rangle;"> &langle; &delta; <sub>mag</sub> &rangle; <sub>100s</sub>  </th>
+          <th data-toggle="tooltip" data-placement="top" data-html="true" title="Mean magnitude"> &langle; mag &rangle; </th>
+          <th data-toggle="tooltip" data-placement="top" data-html="true" title="Magnitude uncertainty"> &sigma;<sub>mag</sub> </th>
+          <th> Comments </th>
+        </tr>
+        {%- for s in obs_stats %}
+        <tr {%- if not s.obs_ok %} class="table-danger" {% endif %}>
+          <td> <a href="https://web-kadi.cfa.harvard.edu/mica/?obsid_or_date={{ s.obsid }}"> {{ s.obsid }} </td>
+          <td> {{ s.mp_starcat_time }} </td>
+          <td> {{ "%.1f" | format(s.row) }} </td>
+          <td> {{ "%.1f" | format(s.col) }} </td>
+          <!-- td> {{ s.obs_ok }} </td -->
+          <td> {{ s.n }} </td>
+          <td> {{ s.n_ok }} </td>
+          <td> {{ s.outliers }} </td>
+          <td> {{ "%.1f" | format(100*s.f_track) }}% </td>
+          <td> {{ "%.1f" | format(100*s.f_dr3) }}% </td>
+          <td> {{ "%.1f" | format(100*s.f_dr5) }}% </td>
+          <td> {{ "%.1f" | format(100*s.f_ok) }}% </td>
+          <td> {{ "%.2f" | format(s.lf_variability_100s) }} </td>
+          <td> {{ "%.2f" | format(s.t_mean) }} </td>
+          <td> {{ "%.2f" | format(s.t_mean_err) }} </td>
+          <td> {{ s.comments }} </td>
+        </tr>
+        {%- endfor %}
+      </table>
+  
+    </div>
+  </body>
+</html>

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -14,7 +14,6 @@ import numpy as np
 from astropy import table
 from astropy import time, units as u
 
-import agasc
 from agasc.supplement.magnitudes import star_obs_catalogs, mag_estimate, mag_estimate_report as msr
 from agasc.supplement.utils import save_version
 from cxotime import CxoTime
@@ -289,7 +288,7 @@ def update_supplement(agasc_stats, filename, include_all=True):
         if 'mags' in h5.root:
             h5.remove_node('/mags')
         h5.create_table('/', 'mags', outliers)
-    save_version(filename, mags=agasc.__version__)
+    save_version(filename, 'mags')
 
     return new_stars, updated_stars
 


### PR DESCRIPTION
## Description

This PR adds a functionality to create an obs-status file during the weekly run, which is then used to update the supplement.

It also adds required functionality for the entire cycle to work:
- weekly run -> check report
  - stars with not-ok observations show up red in the report
- edit obs status file
   - the error encountered should be there in the *comments* section
- run the update again, using the same arguments and `--obs-status-file` option. After this:
   - mags should be updated in the supplement,
   - the report is updated
   - stars with *expected* not-ok observations should show up yellow in the report. These are the ones in the `obs` table in the supplement.
   - all *suspect* observations should show up as ok/not-ok in the report, depending on the resolution

This PR includes the following changes:
- refactor get_agasc_stats and get_obs_stats methods so all observations are kept in the final table, even if they fail. This fixes the cases where some observations were missing in the report table.
- Changed the logic by which observations were skipped if they are already in the supplement. Now they are not skipped if the agasc ID is set explicitly. This is needed so the reports are properly updated when obs-status is modified in the supplement.
- Added functionality to automatically save a YAML file with observations that failed or are suspicious.
- Fixes in report
    - to make it more resilient: do not fail if get_telemetry raises an exception.
    - Redefined the meaning of 'n_obs_bad_new' to mean the number of failed observations, which include actual failures and suspect obs.
    - Redefined the 'warning' flag for agasc_stats so it includes stars with no observation at all (hence no "bad" observations).

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing. The following starts from a supplement with no mag-stats. Then inspected the resulting supplement
   ```
   # set it to import supplement from here
   export AGASC_DIR=`pwd`
   cp $SKA/data/agasc/* .;
   cp ~/SAO/ska/data/agasc/miniagasc* .;

   # create a list of interesting stars to test
   echo 331751984 > agasc_id # an OK new star
   echo 991559968 >> agasc_id # star fails (anyway there should be a single-star page for this star)
   echo 505545160 >> agasc_id # only one suspect obs (anyway there should be a singla-star page for this star)
   echo 42864776 >> agasc_id # an OK older star that gets updated
   echo 1200760024 >> agasc_id  # one suspect OBS (the suspect OBS should show up in the single-star page)
   echo 314189096 >> agasc_id
   echo 553396016 >> agasc_id

   # start with a set of OK stars
   agasc-supplement-update --log-level debug --start 2011:151 --stop 2011:152 --report
   agasc-supplement-update --log-level debug --start 2019:280 --stop 2019:281 --report

   # add the interesting stars, check the report and check the resulting obs_status.yml
   agasc-supplement-update --agasc-id-file agasc_id --log-level debug --report
   open supplement_reports/weekly/latest/index.html

   # One could update the supplement 'obs' table with this...
   # agasc-supplement-obs-status --obs-status-file obs_status.yml # check supplement

   # but that would not update the existing report. We do the following instead
   # the important thing is that the report directory must be the same, otherwise it does not work
   # the report directory is given by the stop time (this still needs a better approach)
   agasc-supplement-update --obs-status-file obs_status.yml --log-level debug --report # all failures should be cleared, pages still there
   ```
  
Fixes #57 