### PR TITLE
Added supplement versions table

### DIFF
--- a/agasc/scripts/update_obs_status.py
+++ b/agasc/scripts/update_obs_status.py
@@ -81,7 +81,7 @@ def add_bad_star(bad_star_ids, bad_star_source, suppl_file, dry_run, create=Fals
     logger.info('The wiki page also includes instructions for test, review, approval')
     logger.info('and installation.')
     if not dry_run:
-        dat.write(suppl_file, format='hdf5', path='bad', append=True, overwrite=True)
+        dat.write(str(suppl_file), format='hdf5', path='bad', append=True, overwrite=True)
         save_version(suppl_file, 'bad')
 
 

--- a/agasc/scripts/update_obs_status.py
+++ b/agasc/scripts/update_obs_status.py
@@ -83,7 +83,7 @@ def add_bad_star(bad_star_ids, bad_star_source, suppl_file, dry_run, create=Fals
     logger.info('and installation.')
     if not dry_run:
         dat.write(suppl_file, format='hdf5', path='bad', append=True, overwrite=True)
-        save_version(suppl_file, bad=agasc.__version__)
+        save_version(suppl_file, 'bad')
 
 
 def update_obs_table(filename, obs_status_override, dry_run=False, create=False):
@@ -149,7 +149,7 @@ def update_obs_table(filename, obs_status_override, dry_run=False, create=False)
 
     if not dry_run:
         obs_status.write(filename, format='hdf5', path='obs', append=True, overwrite=True)
-        save_version(filename, obs=agasc.__version__)
+        save_version(filename, 'obs')
     else:
         logger.info('dry run, not saving anything')
 

--- a/agasc/scripts/update_obs_status.py
+++ b/agasc/scripts/update_obs_status.py
@@ -17,7 +17,9 @@ import numpy as np
 from astropy import table
 import pyyaks.logger
 
+import agasc
 from agasc.supplement.magnitudes import star_obs_catalogs
+from agasc.supplement.utils import save_version
 
 logger = logging.getLogger('agasc.supplement')
 
@@ -76,6 +78,7 @@ def add_bad_star(bad_star_ids, bad_star_source, suppl_file, dry_run):
     logger.info('and installation.')
     if not dry_run:
         dat.write(str(suppl_file), format='hdf5', path='bad', append=True, overwrite=True)
+        save_version(suppl_file, obs=agasc.__version__)
 
 
 def update_obs_table(filename, obs_status_override, dry_run=False):
@@ -138,6 +141,7 @@ def update_obs_table(filename, obs_status_override, dry_run=False):
 
     if not dry_run:
         obs_status.write(str(filename), format='hdf5', path='obs', append=True, overwrite=True)
+        save_version(filename, obs=agasc.__version__)
     else:
         logger.info('dry run, not saving anything')
 

--- a/agasc/scripts/update_obs_status.py
+++ b/agasc/scripts/update_obs_status.py
@@ -17,7 +17,6 @@ import numpy as np
 from astropy import table
 import pyyaks.logger
 
-import agasc
 from agasc.supplement.magnitudes import star_obs_catalogs
 from agasc.supplement.utils import save_version
 

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -13,7 +13,9 @@ import numpy as np
 from astropy import table
 from astropy import time, units as u
 
+import agasc
 from agasc.supplement.magnitudes import star_obs_catalogs, mag_estimate, mag_estimate_report as msr
+from agasc.supplement.utils import save_version
 from cxotime import CxoTime
 
 
@@ -283,6 +285,7 @@ def update_supplement(agasc_stats, filename, include_all=True):
         if 'mags' in h5.root:
             h5.remove_node('/mags')
         h5.create_table('/', 'mags', outliers)
+    save_version(filename, mags=agasc.__version__)
 
     return new_stars, updated_stars
 

--- a/agasc/supplement/utils.py
+++ b/agasc/supplement/utils.py
@@ -95,7 +95,7 @@ def _load_or_create(filename, table_name):
     return table
 
 
-def save_version(filename, **kwargs):
+def save_version(filename, table_name):
     """Save the version of a supplement table to the "versions" table.
 
     Along with the version, the time of update is also added to another table called "last_updated"
@@ -111,9 +111,11 @@ def save_version(filename, **kwargs):
         versions = get_supplement_table('agasc_versions')
 
     :param filename: pathlib.Path
-    :param kwargs: dict
-        A dictionary of table name/version pairs,
+    :param table_name: str or list
     """
+    if isinstance(table_name, str):
+        table_name = [table_name]
+
     import agasc
     filename = Path(filename)
 
@@ -122,10 +124,10 @@ def save_version(filename, **kwargs):
 
     time = CxoTime.now()
     time.precision = 0
-    kwargs.update({'supplement': agasc.__version__})
-    for key, value in kwargs.items():
+    table_name.append('supplement')
+    for key in table_name:
         logger.debug(f'Adding "{key}" to supplement "agasc_versions" and "last_updated" table')
-        versions[key] = [value]
+        versions[key] = [agasc.__version__]
         last_updated[key] = [time.iso]
 
     versions.write(filename, format='hdf5', path='agasc_versions',

--- a/agasc/supplement/utils.py
+++ b/agasc/supplement/utils.py
@@ -130,7 +130,7 @@ def save_version(filename, table_name):
         versions[key] = [agasc.__version__]
         last_updated[key] = [time.iso]
 
-    versions.write(filename, format='hdf5', path='agasc_versions',
+    versions.write(str(filename), format='hdf5', path='agasc_versions',
                    append=True, overwrite=True)
-    last_updated.write(filename, format='hdf5', path='last_updated',
+    last_updated.write(str(filename), format='hdf5', path='last_updated',
                        append=True, overwrite=True)

--- a/agasc/tests/test_obs_status.py
+++ b/agasc/tests/test_obs_status.py
@@ -444,10 +444,8 @@ def test_save_version(monkeypatch):
     # write method is called
     import agasc
     versions = dict(obs=agasc.__version__, mags=agasc.__version__)
-    print("HERE")
 
     def mock_write(*args, **kwargs):
-        print('KEYS', kwargs.keys())
         assert 'format' in kwargs and kwargs['format'] == 'hdf5'
         assert 'path' in kwargs
         assert kwargs['path'] in ['last_updated', 'agasc_versions']

--- a/agasc/tests/test_obs_status.py
+++ b/agasc/tests/test_obs_status.py
@@ -367,7 +367,7 @@ def test_update_obs_blank_slate(monkeypatch):
     monkeypatch.setattr(star_obs_catalogs, 'STARS_OBS', STARS_OBS)
 
     def mock_write(fname, *args, **kwargs):
-        assert kwargs['path'] in ['versions', 'last_updated', 'obs']
+        assert kwargs['path'] in ['agasc_versions', 'last_updated', 'obs']
         if kwargs['path'] == 'obs':
             obs_status = {
                 (r['obsid'], r['agasc_id']): {'status': r['status'], 'comments': r['comments']}
@@ -443,14 +443,16 @@ def test_save_version(monkeypatch):
     # it then checks that a corresponding astropy table with the right structure is created and its
     # write method is called
     versions = dict(obs='v2.3', mags='v1.1')
+    print("HERE")
 
     def mock_write(*args, **kwargs):
+        print('KEYS', kwargs.keys())
         assert 'format' in kwargs and kwargs['format'] == 'hdf5'
         assert 'path' in kwargs
-        assert kwargs['path'] in ['last_updated', 'versions']
+        assert kwargs['path'] in ['last_updated', 'agasc_versions']
         assert len(args[0]) == 1
         assert 'supplement' in args[0].colnames
-        if kwargs['path'] == 'versions':
+        if kwargs['path'] == 'agasc_versions':
             for k, v in versions.items():
                 assert k in args[0].colnames
                 assert args[0][k][0] == versions[k]

--- a/agasc/tests/test_obs_status.py
+++ b/agasc/tests/test_obs_status.py
@@ -442,7 +442,8 @@ def test_save_version(monkeypatch):
     # this test takes the following dictionary and passes it to save_version
     # it then checks that a corresponding astropy table with the right structure is created and its
     # write method is called
-    versions = dict(obs='v2.3', mags='v1.1')
+    import agasc
+    versions = dict(obs=agasc.__version__, mags=agasc.__version__)
     print("HERE")
 
     def mock_write(*args, **kwargs):
@@ -460,4 +461,4 @@ def test_save_version(monkeypatch):
     monkeypatch.setattr(table.Table, 'write', mock_write)
 
     from agasc.supplement.utils import save_version
-    save_version('test_save_version.h5', **versions)
+    save_version('test_save_version.h5', ['obs', 'mags'])


### PR DESCRIPTION
## Description

This PR adds two tables to the supplement:
- versions
- last_updated

They have the same structure. Each is a one-row table with string dtype. It is easy to remove the `last_updated` table if you prefer not to have it.

I thought of the following options:
- saving as meta data for each table. Jean wanted a global version as well, plus there should be a method to retrieve versions, and we already have `utils.get_supplement_table`
- saving in a single table, with one row for each existing table, one column for version and another for last_updated. This is fine. It just meant the user code had to jump through some hoops to get the version.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing. You can run this:
   ```
   (ska3-flight-2021.2rc4) javierg agasc $ export AGASC_DIR=`pwd`/test
   (ska3-flight-2021.2rc4) javierg agasc $ ipython
   Python 3.8.3 (default, Jul  2 2020, 11:26:31) 
   Type 'copyright', 'credits' or 'license' for more information
   IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.
   histogram not found

   In [1]: import logging 
      ...: logging.basicConfig(level='DEBUG') 
      ...: import agasc 
      ...: from agasc.supplement.utils import save_version, get_supplement_table 
      ...: from agasc.supplement.utils import save_version, get_supplement_table 
      ...: filename = 'test/agasc_supplement.h5' 
      ...: save_version(filename, obs=agasc.__version__, mags=agasc.__version__, bad=agasc.__version__) 
      ...:                                                                                                                                                      
   DEBUG:agasc.supplement:Creating agasc supplement table "versions"
   DEBUG:agasc.supplement:Creating agasc supplement table "last_updated"
   DEBUG:agasc.supplement:Adding "obs" to agasc supplement "versions" table
   DEBUG:agasc.supplement:Adding "obs" to agasc supplement "last_updated" table
   DEBUG:agasc.supplement:Adding "mags" to agasc supplement "versions" table
   DEBUG:agasc.supplement:Adding "mags" to agasc supplement "last_updated" table
   DEBUG:agasc.supplement:Adding "bad" to agasc supplement "versions" table
   DEBUG:agasc.supplement:Adding "bad" to agasc supplement "last_updated" table
   DEBUG:agasc.supplement:Adding "supplement" to agasc supplement "versions" table
   DEBUG:agasc.supplement:Adding "supplement" to agasc supplement "last_updated" table
   In [2]: get_supplement_table('versions')                                                                                                                     
   Out[2]: 
   <Table length=1>
            obs                   mags                  bad                supplement     
          bytes32               bytes32               bytes32               bytes32       
   --------------------- --------------------- --------------------- ---------------------
   4.10.3.dev89+g8c21663 4.10.3.dev89+g8c21663 4.10.3.dev89+g8c21663 4.10.3.dev89+g8c21663

   In [3]: get_supplement_table('last_updated')                                                                                                                 
   Out[3]: 
   <Table length=1>
             obs                     mags                    bad                  supplement      
           bytes32                 bytes32                 bytes32                 bytes32        
   ----------------------- ----------------------- ----------------------- -----------------------
   2021-02-11 19:11:48.412 2021-02-11 19:11:48.412 2021-02-11 19:11:48.412 2021-02-11 19:11:48.412
   ```

Fixes #74