### PR TITLE
Added a mechanism to log command-line arguments to be able to re-run

### DIFF
--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -816,7 +816,6 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
 
     n_obsids = len(star_obs)
 
-    print('obs_status_override', obs_status_override)
     # exclude star_obs that are in obs_status_override with status != 0
     excluded_obs = np.array([((oi, ai) in obs_status_override
                              and obs_status_override[(oi, ai)]['status'] != 0)


### PR DESCRIPTION
## Description

This PR adds the possibility to save a YAML file (we could change it to json, if people prefer...) to log command-line arguments.

When `--start/stop` are not given, we want to first set the arguments and then save, so the next time one runs the script these are explicit, and not determined according to the new date. Some arguments used to be modified inside `agasc.supplement.magnitudes.update_mag_supplement.do`, and they were moved so they are modified before saving the arguments to file.

 I also modified the arguments and docstrings of `agasc.supplement.magnitudes.update_mag_supplement.do`

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing.

I am using [AGASC ID 553396016](https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement_reports/stars/055/553396016/index.html) to test. This star has a suspect observation and has been observed multiple times since then.
```
# starting from and empty directory
# set it to import supplement from here
export AGASC_DIR=`pwd`
cp $SKA/data/agasc/* .;

# this day includes an observation of AGASC ID 553396016
agasc-update-magnitudes --log-level debug --start 2019:362 --stop 2019:363 --report

# the following has a suspect observation of AGASC ID 553396016
agasc-update-magnitudes --log-level debug --start 2020:096 --stop 2020:097 --report

# this should add the suspect observation to the supplement so it is not counted as a failure
agasc-update-magnitudes --obs-status-file obs_status.yml --args-file supplement_reports/weekly/latest/call_args.yml

# we can check that the observation is now yellow in the dashboard
# AND that there are not observations after 2020:097
open supplement_reports/weekly/latest/index.html
```

Fixes #90