### PR TITLE
Obs status initial dispositions (DO NOT MERGE)

### DIFF
--- a/obs_status.yml
+++ b/obs_status.yml
@@ -1,0 +1,870 @@
+obs:
+  - observation_id: 2007:332:13:03:23.621
+    status: 1
+    agasc_id: [5115672]
+    comments: Suspect observation
+  - observation_id: 2013:323:16:25:05.901
+    status: 1
+    agasc_id: [5115672]
+    comments: Suspect observation
+  - observation_id: 2005:056:20:11:01.041
+    status: 1
+    agasc_id: [35263288]
+    comments: Suspect observation
+  - observation_id: 2016:353:16:03:20.817
+    status: 1
+    agasc_id: [38281624]
+    comments: Suspect observation
+  - observation_id: 2008:057:22:07:34.020
+    status: 1
+    agasc_id: [38535536]
+    comments: Suspect observation
+  - observation_id: 2013:128:05:54:19.223
+    status: 1
+    agasc_id: [38535536]
+    comments: Suspect observation
+  - observation_id: 2012:065:14:30:29.432
+    status: 1
+    agasc_id: [40113272]
+    comments: Suspect observation
+  - observation_id: 2020:259:07:03:15.474
+    status: 1
+    agasc_id: [42864912]
+    comments: Suspect observation
+  - observation_id: 2017:119:02:36:19.023
+    status: 1
+    agasc_id: [45616472]
+    comments: Suspect observation
+  - observation_id: 2006:159:12:19:26.972
+    status: 1
+    agasc_id: [46794712]
+    comments: Suspect observation
+  - observation_id: 2006:159:22:22:16.972
+    status: 1
+    agasc_id: [46794712]
+    comments: Suspect observation
+  - observation_id: 2010:247:10:06:38.225
+    status: 1
+    agasc_id: [47846640]
+    comments: Suspect observation
+  - observation_id: 2006:162:12:54:27.115
+    status: 1
+    agasc_id: [48892720]
+    comments: Suspect observation
+  - observation_id: 2018:165:06:34:21.353
+    status: 1
+    agasc_id: [49818760]
+    comments: Suspect observation
+  - observation_id: 2016:168:00:15:13.230
+    status: 1
+    agasc_id: [52955968]
+    comments: Suspect observation
+  - observation_id: 2013:070:01:06:51.112
+    status: 1
+    agasc_id: [62922104]
+    comments: Suspect observation
+  - observation_id: 2010:240:04:26:18.932
+    status: 1
+    agasc_id: [68956456]
+    comments: Suspect observation
+  - observation_id: 2020:304:03:02:34.117
+    status: 1
+    agasc_id: [82972168]
+    comments: Suspect observation
+  - observation_id: 2017:354:04:35:24.949
+    status: 1
+    agasc_id: [92812824]
+    comments: Suspect observation
+  - observation_id: 2013:276:01:38:23.187
+    status: 1
+    agasc_id: [107743264]
+    comments: Suspect observation
+  - observation_id: 2013:067:05:41:05.787
+    status: 1
+    agasc_id: [107881800]
+    comments: Suspect observation
+  - observation_id: 2019:035:04:23:05.219
+    status: 1
+    agasc_id: [109061768]
+    comments: Suspect observation
+  - observation_id: 2020:055:11:57:17.800
+    status: 1
+    agasc_id: [110493968]
+    comments: Suspect observation
+  - observation_id: 2015:032:15:55:37.026
+    status: 1
+    agasc_id: [111807640]
+    comments: Suspect observation
+  - observation_id: 2013:118:00:07:27.863
+    status: 1
+    agasc_id: [116657928]
+    comments: Suspect observation
+  - observation_id: 2016:127:20:16:33.087
+    status: 1
+    agasc_id: [118096888]
+    comments: Suspect observation
+  - observation_id: 2012:092:01:34:23.764
+    status: 1
+    agasc_id: [118359864]
+    comments: Suspect observation
+  - observation_id: 2016:141:00:48:34.306
+    status: 1
+    agasc_id: [118359864]
+    comments: Suspect observation
+  - observation_id: 2006:014:13:25:39.795
+    status: 1
+    agasc_id: [118498608]
+    comments: Suspect observation
+  - observation_id: 2019:121:21:47:55.999
+    status: 1
+    agasc_id: [120457376]
+    comments: Suspect observation
+  - observation_id: 2019:357:18:41:21.840
+    status: 1
+    agasc_id: [122159368]
+    comments: Suspect observation
+  - observation_id: 2018:014:04:03:16.301
+    status: 1
+    agasc_id: [123874048]
+    comments: Suspect observation
+  - observation_id: 2013:210:03:07:53.465
+    status: 1
+    agasc_id: [139214712]
+    comments: Suspect observation
+  - observation_id: 2015:233:22:11:26.142
+    status: 1
+    agasc_id: [144714600]
+    comments: Suspect observation
+  - observation_id: 2015:234:03:22:43.521
+    status: 1
+    agasc_id: [144714600]
+    comments: Suspect observation
+  - observation_id: 2012:224:10:13:18.941
+    status: 1
+    agasc_id: [145113736]
+    comments: Suspect observation
+  - observation_id: 2013:255:01:55:56.262
+    status: 1
+    agasc_id: [152831696]
+    comments: Suspect observation
+  - observation_id: 2014:241:18:41:28.744
+    status: 1
+    agasc_id: [153631040]
+    comments: Suspect observation
+  - observation_id: 2019:304:07:33:22.655
+    status: 1
+    agasc_id: [157951008]
+    comments: Suspect observation
+  - observation_id: 2004:315:16:15:06.000
+    status: 1
+    agasc_id: [161354744]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2004:315:16:15:06.000
+    status: 1
+    agasc_id: [161355344]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2009:345:18:09:20.636
+    status: 1
+    agasc_id: [161357600]
+    comments: Suspect observation
+  - observation_id: 2019:336:01:10:48.142
+    status: 1
+    agasc_id: [166993856]
+    comments: Suspect observation
+  - observation_id: 2018:330:13:00:19.280
+    status: 1
+    agasc_id: [168038608]
+    comments: Suspect observation
+  - observation_id: 2020:362:06:19:56.505
+    status: 1
+    agasc_id: [175375720]
+    comments: Suspect observation
+  - observation_id: 2011:076:10:15:21.875
+    status: 1
+    agasc_id: [186125624]
+    comments: Suspect observation
+  - observation_id: 2020:060:11:59:00.012
+    status: 1
+    agasc_id: [187829568]
+    comments: Suspect observation
+  - observation_id: 2004:055:07:41:03.254
+    status: 1
+    agasc_id: [188482256]
+    comments: Suspect observation
+  - observation_id: 2019:113:10:12:41.647
+    status: 1
+    agasc_id: [188501784]
+    comments: Suspect observation
+  - observation_id: 2013:085:22:55:02.786
+    status: 1
+    agasc_id: [188623712]
+    comments: Suspect observation
+  - observation_id: 2014:099:03:23:57.530
+    status: 1
+    agasc_id: [188750920]
+    comments: Suspect observation
+  - observation_id: 2010:084:04:33:25.441
+    status: 1
+    agasc_id: [190716896]
+    comments: Suspect observation
+  - observation_id: 2011:248:04:00:06.000
+    status: 1
+    agasc_id: [225576592]
+    comments: Suspect observation
+  - observation_id: 2008:360:18:18:07.733
+    status: 1
+    agasc_id: [225713936]
+    comments: Suspect observation
+  - observation_id: 2013:287:00:21:21.738
+    status: 1
+    agasc_id: [232129104]
+    comments: Suspect observation
+  - observation_id: 2010:359:04:11:19.911
+    status: 1
+    agasc_id: [239080480]
+    comments: Suspect observation
+  - observation_id: 2005:038:01:15:06.000
+    status: 1
+    agasc_id: [257953336]
+    comments: Suspect observation
+  - observation_id: 2017:050:14:02:45.940
+    status: 1
+    agasc_id: [259801408]
+    comments: Suspect observation
+  - observation_id: 2013:048:18:59:05.061
+    status: 1
+    agasc_id: [264115840]
+    comments: Suspect observation
+  - observation_id: 2013:048:21:37:10.984
+    status: 1
+    agasc_id: [264115840]
+    comments: Suspect observation
+  - observation_id: 2020:213:00:44:44.466
+    status: 1
+    agasc_id: [265817216]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2015:125:13:11:24.129
+    status: 1
+    agasc_id: [288753656]
+    comments: Suspect observation
+  - observation_id: 2011:338:07:22:12.671
+    status: 1
+    agasc_id: [306200176]
+    comments: Suspect observation
+  - observation_id: 2017:198:09:20:24.644
+    status: 1
+    agasc_id: [311824376]
+    comments: Suspect observation
+  - observation_id: 2016:324:12:21:46.079
+    status: 1
+    agasc_id: [314186320]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2016:324:12:21:46.079
+    status: 1
+    agasc_id: [314189096]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2016:324:12:21:46.079
+    status: 1
+    agasc_id: [314318832]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2016:324:12:21:46.079
+    status: 1
+    agasc_id: [314321208]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2012:279:07:23:25.438
+    status: 1
+    agasc_id: [327945264]
+    comments: Suspect observation
+  - observation_id: 2014:154:19:18:14.391
+    status: 1
+    agasc_id: [328077952]
+    comments: Suspect observation
+  - observation_id: 2017:065:23:54:36.113
+    status: 1
+    agasc_id: [328078016]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2017:065:23:54:36.113
+    status: 1
+    agasc_id: [328078824]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2017:065:23:54:36.113
+    status: 1
+    agasc_id: [328080896]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2017:065:23:54:36.113
+    status: 1
+    agasc_id: [328081232]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2017:065:23:54:36.113
+    status: 1
+    agasc_id: [328081352]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2006:064:07:51:01.152
+    status: 1
+    agasc_id: [330967424]
+    comments: Suspect observation
+  - observation_id: 2009:335:11:29:27.547
+    status: 1
+    agasc_id: [373564272]
+    comments: Suspect observation
+  - observation_id: 2015:331:14:10:26.457
+    status: 1
+    agasc_id: [376724944]
+    comments: Suspect observation
+  - observation_id: 2011:094:17:16:49.408
+    status: 1
+    agasc_id: [377102496]
+    comments: Suspect observation
+  - observation_id: 2017:314:20:46:46.000
+    status: 1
+    agasc_id: [377102496]
+    comments: Suspect observation
+  - observation_id: 2010:042:06:34:25.316
+    status: 1
+    agasc_id: [391120072]
+    comments: Suspect observation
+  - observation_id: 2016:016:23:14:43.286
+    status: 1
+    agasc_id: [392040448]
+    comments: Suspect observation
+  - observation_id: 2016:019:15:29:09.671
+    status: 1
+    agasc_id: [392040448]
+    comments: Suspect observation
+  - observation_id: 2009:040:05:37:54.381
+    status: 1
+    agasc_id: [395055600]
+    comments: Suspect observation
+  - observation_id: 2014:284:03:45:32.148
+    status: 1
+    agasc_id: [396501520]
+    comments: Suspect observation
+  - observation_id: 2014:284:07:21:19.725
+    status: 1
+    agasc_id: [396501520]
+    comments: Suspect observation
+  - observation_id: 2020:240:12:46:53.718
+    status: 1
+    agasc_id: [396501520]
+    comments: Suspect observation
+  - observation_id: 2020:243:11:17:18.150
+    status: 1
+    agasc_id: [396501520]
+    comments: Suspect observation
+  - observation_id: 2020:266:08:19:47.944
+    status: 1
+    agasc_id: [405276920]
+    comments: Suspect observation
+  - observation_id: 2016:062:05:39:12.185
+    status: 1
+    agasc_id: [417611952]
+    comments: Suspect observation
+  - observation_id: 2013:014:06:48:36.232
+    status: 1
+    agasc_id: [450103168]
+    comments: Suspect observation
+  - observation_id: 2017:048:23:37:39.502
+    status: 1
+    agasc_id: [452728616]
+    comments: Suspect observation
+  - observation_id: 2016:136:08:42:06.470
+    status: 1
+    agasc_id: [458500128]
+    comments: Suspect observation
+  - observation_id: 2010:004:19:53:30.715
+    status: 1
+    agasc_id: [497824592]
+    comments: Suspect observation
+  - observation_id: 2015:231:00:04:31.256
+    status: 1
+    agasc_id: [500706352]
+    comments: Suspect observation
+  - observation_id: 2014:159:03:53:31.631
+    status: 1
+    agasc_id: [505545160]
+    comments: Suspect observation
+  - observation_id: 2010:285:03:11:03.570
+    status: 1
+    agasc_id: [612763008]
+    comments: Suspect observation
+  - observation_id: 2010:285:03:49:31.385
+    status: 1
+    agasc_id: [612763008]
+    comments: Suspect observation
+  - observation_id: 2011:269:04:58:50.064
+    status: 1
+    agasc_id: [614482704]
+    comments: Suspect observation
+  - observation_id: 2016:021:00:11:54.978
+    status: 1
+    agasc_id: [615257632]
+    comments: Suspect observation
+  - observation_id: 2016:279:23:36:33.516
+    status: 1
+    agasc_id: [615257632]
+    comments: Suspect observation
+  - observation_id: 2005:281:04:44:20.882
+    status: 1
+    agasc_id: [615914552]
+    comments: Suspect observation
+  - observation_id: 2010:303:16:32:24.578
+    status: 1
+    agasc_id: [616432288]
+    comments: Suspect observation
+  - observation_id: 2009:290:21:44:31.992
+    status: 1
+    agasc_id: [616699752]
+    comments: Suspect observation
+  - observation_id: 2014:122:17:49:13.654
+    status: 1
+    agasc_id: [626667256]
+    comments: Suspect observation
+  - observation_id: 2009:023:22:13:56.794
+    status: 1
+    agasc_id: [639635448]
+    comments: Suspect observation
+  - observation_id: 2009:024:04:12:45.955
+    status: 1
+    agasc_id: [639635448]
+    comments: Suspect observation
+  - observation_id: 2016:027:20:27:48.432
+    status: 1
+    agasc_id: [643702120]
+    comments: Suspect observation
+  - observation_id: 2011:108:03:39:32.321
+    status: 1
+    agasc_id: [647762704]
+    comments: Suspect observation
+  - observation_id: 2014:138:12:18:55.415
+    status: 1
+    agasc_id: [649070072]
+    comments: Suspect observation
+  - observation_id: 2018:081:21:42:04.564
+    status: 1
+    agasc_id: [651037128]
+    comments: Suspect observation
+  - observation_id: 2005:150:01:28:35.423
+    status: 1
+    agasc_id: [652480464]
+    comments: Suspect observation
+  - observation_id: 2012:187:04:30:17.984
+    status: 1
+    agasc_id: [653529952]
+    comments: Suspect observation
+  - observation_id: 2015:212:20:00:08.125
+    status: 1
+    agasc_id: [653529952]
+    comments: Suspect observation
+  - observation_id: 2018:002:23:37:48.551
+    status: 1
+    agasc_id: [653529952]
+    comments: Suspect observation
+  - observation_id: 2013:091:02:18:06.000
+    status: 1
+    agasc_id: [653919168]
+    comments: Suspect observation
+  - observation_id: 2004:109:04:09:26.608
+    status: 1
+    agasc_id: [654050016]
+    comments: Suspect observation
+  - observation_id: 2012:174:04:58:32.901
+    status: 1
+    agasc_id: [664279632]
+    comments: Suspect observation
+  - observation_id: 2011:187:11:50:08.646
+    status: 1
+    agasc_id: [665715168]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2007:231:04:53:28.518
+    status: 1
+    agasc_id: [676336280]
+    comments: Suspect observation
+  - observation_id: 2003:221:17:58:51.959
+    status: 1
+    agasc_id: [686557584]
+    comments: Suspect observation
+  - observation_id: 2020:272:02:24:05.125
+    status: 1
+    agasc_id: [686557584]
+    comments: Suspect observation
+  - observation_id: 2020:272:02:24:05.125
+    status: 1
+    agasc_id: [686557784]
+    comments: Suspect observation
+  - observation_id: 2013:233:19:29:39.426
+    status: 1
+    agasc_id: [689441328]
+    comments: Suspect observation
+  - observation_id: 2013:236:10:47:05.212
+    status: 1
+    agasc_id: [689441328]
+    comments: Suspect observation
+  - observation_id: 2008:292:16:48:37.657
+    status: 1
+    agasc_id: [690096648]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2020:267:05:49:07.272
+    status: 1
+    agasc_id: [690625640]
+    comments: Suspect observation
+  - observation_id: 2007:289:08:56:36.694
+    status: 1
+    agasc_id: [693243160]
+    comments: Suspect observation
+  - observation_id: 2020:228:13:19:56.547
+    status: 1
+    agasc_id: [694561568]
+    comments: Suspect observation
+  - observation_id: 2006:040:05:48:01.364
+    status: 1
+    agasc_id: [711341336]
+    comments: Suspect observation
+  - observation_id: 2009:049:20:22:15.791
+    status: 1
+    agasc_id: [720504096]
+    comments: Suspect observation
+  - observation_id: 2007:077:02:38:38.764
+    status: 1
+    agasc_id: [722741568]
+    comments: Suspect observation
+  - observation_id: 2005:103:22:36:24.446
+    status: 1
+    agasc_id: [723521752]
+    comments: Suspect observation
+  - observation_id: 2005:074:22:44:33.953
+    status: 1
+    agasc_id: [723651200]
+    comments: Suspect observation
+  - observation_id: 2005:074:22:44:33.953
+    status: 1
+    agasc_id: [723657296]
+    comments: Suspect observation
+  - observation_id: 2005:348:06:20:08.102
+    status: 1
+    agasc_id: [728370040]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2018:158:10:17:36.762
+    status: 1
+    agasc_id: [738075032]
+    comments: Suspect observation
+  - observation_id: 2011:187:11:50:08.646
+    status: 1
+    agasc_id: [741605832]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2011:187:11:50:08.646
+    status: 1
+    agasc_id: [741605976]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2011:187:11:50:08.646
+    status: 1
+    agasc_id: [741607368]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2011:187:11:50:08.646
+    status: 1
+    agasc_id: [741609000]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2011:187:11:50:08.646
+    status: 1
+    agasc_id: [741610072]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2011:187:11:50:08.646
+    status: 1
+    agasc_id: [741736560]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2011:187:11:50:08.646
+    status: 1
+    agasc_id: [741736840]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2018:198:01:56:54.706
+    status: 1
+    agasc_id: [745014832]
+    comments: Suspect observation
+  - observation_id: 2006:086:15:29:13.448
+    status: 1
+    agasc_id: [757735584]
+    comments: Suspect observation
+  - observation_id: 2006:086:19:12:53.448
+    status: 1
+    agasc_id: [759439008]
+    comments: Suspect observation
+  - observation_id: 2006:086:21:04:43.448
+    status: 1
+    agasc_id: [759439008]
+    comments: Suspect observation
+  - observation_id: 2006:086:22:56:33.448
+    status: 1
+    agasc_id: [759439008]
+    comments: Suspect observation
+  - observation_id: 2006:087:00:48:23.448
+    status: 1
+    agasc_id: [759439008]
+    comments: Suspect observation
+  - observation_id: 2019:248:14:52:31.156
+    status: 1
+    agasc_id: [759694976]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2019:248:14:52:31.156
+    status: 1
+    agasc_id: [759696752]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2019:248:14:52:31.156
+    status: 1
+    agasc_id: [759698088]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2019:248:14:52:31.156
+    status: 1
+    agasc_id: [759701600]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2006:212:07:39:07.107
+    status: 1
+    agasc_id: [763893760]
+    comments: Suspect observation
+  - observation_id: 2011:285:11:34:00.061
+    status: 1
+    agasc_id: [764150080]
+    comments: Suspect observation
+  - observation_id: 2017:196:02:40:43.206
+    status: 1
+    agasc_id: [770973104]
+    comments: Suspect observation
+  - observation_id: 2014:096:05:02:19.545
+    status: 1
+    agasc_id: [771756656]
+    comments: Suspect observation
+  - observation_id: 2020:083:13:35:57.577
+    status: 1
+    agasc_id: [798760200]
+    comments: Suspect observation
+  - observation_id: 2010:089:12:06:07.502
+    status: 1
+    agasc_id: [805966472]
+    comments: Suspect observation
+  - observation_id: 2015:220:11:07:04.609
+    status: 1
+    agasc_id: [821318496]
+    comments: Suspect observation
+  - observation_id: 2019:245:18:05:01.870
+    status: 1
+    agasc_id: [836381648]
+    comments: Suspect observation
+  - observation_id: 2005:218:04:46:28.211
+    status: 1
+    agasc_id: [838209392]
+    comments: Suspect observation
+  - observation_id: 2020:145:13:55:06.000
+    status: 1
+    agasc_id: [844368576]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2020:145:13:55:06.000
+    status: 1
+    agasc_id: [844375152]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2020:145:13:55:06.000
+    status: 1
+    agasc_id: [845289720]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2020:145:13:55:06.000
+    status: 1
+    agasc_id: [845293880]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2003:357:02:49:14.852
+    status: 1
+    agasc_id: [857375576]
+    comments: Suspect observation
+  - observation_id: 2007:085:18:25:58.626
+    status: 1
+    agasc_id: [879768704]
+    comments: Suspect observation
+  - observation_id: 2013:088:15:35:07.782
+    status: 1
+    agasc_id: [879768704]
+    comments: Suspect observation
+  - observation_id: 2020:139:21:23:16.181
+    status: 1
+    agasc_id: [891159184]
+    comments: Suspect observation
+  - observation_id: 2020:140:00:46:15.767
+    status: 1
+    agasc_id: [891159184]
+    comments: Suspect observation
+  - observation_id: 2003:228:21:05:34.379
+    status: 1
+    agasc_id: [897878136]
+    comments: Suspect observation
+  - observation_id: 2013:312:16:48:35.039
+    status: 1
+    agasc_id: [897988944]
+    comments: Suspect observation
+  - observation_id: 2013:312:19:25:25.039
+    status: 1
+    agasc_id: [897988944]
+    comments: Suspect observation
+  - observation_id: 2013:312:03:11:14.093
+    status: 1
+    agasc_id: [897996696]
+    comments: Suspect observation
+  - observation_id: 2013:312:06:21:15.039
+    status: 1
+    agasc_id: [897996696]
+    comments: Suspect observation
+  - observation_id: 2013:312:08:58:05.039
+    status: 1
+    agasc_id: [897996696]
+    comments: Suspect observation
+  - observation_id: 2013:312:11:34:55.039
+    status: 1
+    agasc_id: [897996696]
+    comments: Suspect observation
+  - observation_id: 2013:312:11:34:55.039
+    status: 1
+    agasc_id: [897999536]
+    comments: Suspect observation
+  - observation_id: 2013:312:14:11:45.039
+    status: 1
+    agasc_id: [897999536]
+    comments: Suspect observation
+  - observation_id: 2013:312:14:11:45.039
+    status: 1
+    agasc_id: [898004384]
+    comments: Suspect observation
+  - observation_id: 2013:312:16:48:35.039
+    status: 1
+    agasc_id: [898004384]
+    comments: Suspect observation
+  - observation_id: 2013:312:19:25:25.039
+    status: 1
+    agasc_id: [898004384]
+    comments: Suspect observation
+  - observation_id: 2013:312:22:02:15.039
+    status: 1
+    agasc_id: [898004384]
+    comments: Suspect observation
+  - observation_id: 2013:313:00:39:05.039
+    status: 1
+    agasc_id: [898004384]
+    comments: Suspect observation
+  - observation_id: 2013:312:22:02:15.039
+    status: 1
+    agasc_id: [898124000]
+    comments: Suspect observation
+  - observation_id: 2013:312:22:02:15.039
+    status: 1
+    agasc_id: [898125104]
+    comments: Suspect observation
+  - observation_id: 2013:313:03:14:15.039
+    status: 1
+    agasc_id: [898125104]
+    comments: Suspect observation
+  - observation_id: 2018:155:22:59:34.754
+    status: 1
+    agasc_id: [899950912]
+    comments: Suspect observation
+  - observation_id: 2003:129:13:39:37.186
+    status: 1
+    agasc_id: [901664112]
+    comments: Suspect observation
+  - observation_id: 2010:221:16:22:00.639
+    status: 1
+    agasc_id: [904010616]
+    comments: Suspect observation
+  - observation_id: 2014:207:06:36:50.665
+    status: 1
+    agasc_id: [910562920]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2014:207:06:36:50.665
+    status: 1
+    agasc_id: [910693856]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2014:207:06:36:50.665
+    status: 1
+    agasc_id: [911082032]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2014:207:06:36:50.665
+    status: 1
+    agasc_id: [911083616]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2014:207:06:36:50.665
+    status: 1
+    agasc_id: [911089528]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2017:259:02:11:04.769
+    status: 1
+    agasc_id: [913441888]
+    comments: Suspect observation
+  - observation_id: 2014:244:14:47:42.617
+    status: 1
+    agasc_id: [915541320]
+    comments: Suspect observation
+  - observation_id: 2014:252:07:42:35.429
+    status: 1
+    agasc_id: [915939232]
+    comments: Suspect observation
+  - observation_id: 2010:142:09:25:14.003
+    status: 1
+    agasc_id: [962998672]
+    comments: Suspect observation
+  - observation_id: 2011:298:22:07:33.000
+    status: 1
+    agasc_id: [966395208]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2008:183:05:33:47.836
+    status: 1
+    agasc_id: [974791856]
+    comments: Suspect observation
+  - observation_id: 2018:214:12:04:13.567
+    status: 1
+    agasc_id: [974925328]
+    comments: Suspect observation
+  - observation_id: 2017:068:16:27:18.823
+    status: 1
+    agasc_id: [991169936]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2017:068:16:27:18.823
+    status: 1
+    agasc_id: [991175320]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2017:068:16:27:18.823
+    status: 1
+    agasc_id: [991564392]
+    comments: Mismatch in telemetry between aca_l0 and cheta
+  - observation_id: 2007:130:19:34:45.821
+    status: 1
+    agasc_id: [1020796600]
+    comments: Suspect observation
+  - observation_id: 2011:343:07:05:57.421
+    status: 1
+    agasc_id: [1058938112]
+    comments: Suspect observation
+  - observation_id: 2013:105:10:22:09.169
+    status: 1
+    agasc_id: [1081092600]
+    comments: Suspect observation
+  - observation_id: 2012:028:20:14:46.841
+    status: 1
+    agasc_id: [1092619768]
+    comments: Suspect observation
+  - observation_id: 2018:069:03:04:54.838
+    status: 1
+    agasc_id: [1105068512]
+    comments: Suspect observation
+  - observation_id: 2013:059:15:13:52.208
+    status: 1
+    agasc_id: [1105592952]
+    comments: Suspect observation
+  - observation_id: 2020:026:14:02:58.573
+    status: 1
+    agasc_id: [1108353064]
+    comments: Suspect observation
+  - observation_id: 2013:299:20:58:47.949
+    status: 1
+    agasc_id: [1143744224]
+    comments: Suspect observation
+  - observation_id: 2011:033:21:23:13.132
+    status: 1
+    agasc_id: [1158028568]
+    comments: Suspect observation
+  - observation_id: 2019:336:03:32:40.722
+    status: 1
+    agasc_id: [1178221128]
+    comments: Suspect observation
+  

--- a/obs_status.yml
+++ b/obs_status.yml
@@ -222,7 +222,7 @@ obs:
   - observation_id: 2010:359:04:11:19.911
     status: 1
     agasc_id: [239080480]
-    comments: Suspect observation
+    comments: Never acquired; set mag to MAXMAG
   - observation_id: 2005:038:01:15:06.000
     status: 1
     agasc_id: [257953336]
@@ -258,19 +258,19 @@ obs:
   - observation_id: 2016:324:12:21:46.079
     status: 1
     agasc_id: [314186320]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: NSM at start of observation
   - observation_id: 2016:324:12:21:46.079
     status: 1
     agasc_id: [314189096]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: NSM at start of observation
   - observation_id: 2016:324:12:21:46.079
     status: 1
     agasc_id: [314318832]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: NSM at start of observation
   - observation_id: 2016:324:12:21:46.079
     status: 1
     agasc_id: [314321208]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: NSM at start of observation
   - observation_id: 2012:279:07:23:25.438
     status: 1
     agasc_id: [327945264]
@@ -338,23 +338,23 @@ obs:
   - observation_id: 2014:284:03:45:32.148
     status: 1
     agasc_id: [396501520]
-    comments: Suspect observation
+    comments: Never acquired; set mag to MAXMAG
   - observation_id: 2014:284:07:21:19.725
     status: 1
     agasc_id: [396501520]
-    comments: Suspect observation
+    comments: Never acquired; set mag to MAXMAG
   - observation_id: 2020:240:12:46:53.718
     status: 1
     agasc_id: [396501520]
-    comments: Suspect observation
+    comments: Never acquired; set mag to MAXMAG
   - observation_id: 2020:243:11:17:18.150
     status: 1
     agasc_id: [396501520]
-    comments: Suspect observation
+    comments: Never acquired; set mag to MAXMAG
   - observation_id: 2020:266:08:19:47.944
     status: 1
     agasc_id: [405276920]
-    comments: Suspect observation
+    comments: Never acquired; set mag to MAXMAG; tracking interval is spurious.
   - observation_id: 2016:062:05:39:12.185
     status: 1
     agasc_id: [417611952]
@@ -382,7 +382,7 @@ obs:
   - observation_id: 2014:159:03:53:31.631
     status: 1
     agasc_id: [505545160]
-    comments: Suspect observation
+    comments: Never acquired; set mag to MAXMAG
   - observation_id: 2010:285:03:11:03.570
     status: 1
     agasc_id: [612763008]
@@ -430,7 +430,7 @@ obs:
   - observation_id: 2016:027:20:27:48.432
     status: 1
     agasc_id: [643702120]
-    comments: Suspect observation
+    comments: Sparse periods of track at 12.5 mag; set mag to MAXMAG
   - observation_id: 2011:108:03:39:32.321
     status: 1
     agasc_id: [647762704]
@@ -476,9 +476,9 @@ obs:
     agasc_id: [665715168]
     comments: Mismatch in telemetry between aca_l0 and cheta
   - observation_id: 2007:231:04:53:28.518
-    status: 1
+    status: 0
     agasc_id: [676336280]
-    comments: Suspect observation
+    comments: Available data look OK, lack of track not understood
   - observation_id: 2003:221:17:58:51.959
     status: 1
     agasc_id: [686557584]
@@ -506,11 +506,11 @@ obs:
   - observation_id: 2020:267:05:49:07.272
     status: 1
     agasc_id: [690625640]
-    comments: Suspect observation
+    comments: Never acquired; set mag to MAXMAG
   - observation_id: 2007:289:08:56:36.694
     status: 1
     agasc_id: [693243160]
-    comments: Suspect observation
+    comments: Too bright; set mag 4.5 +/- 0.1
   - observation_id: 2020:228:13:19:56.547
     status: 1
     agasc_id: [694561568]
@@ -532,9 +532,9 @@ obs:
     agasc_id: [723521752]
     comments: Suspect observation
   - observation_id: 2005:074:22:44:33.953
-    status: 1
+    status: 0
     agasc_id: [723651200]
-    comments: Suspect observation
+    comments: Mostly tracking 12.0 mag star; supplement estimate is 13.9
   - observation_id: 2005:074:22:44:33.953
     status: 1
     agasc_id: [723657296]
@@ -542,7 +542,7 @@ obs:
   - observation_id: 2005:348:06:20:08.102
     status: 1
     agasc_id: [728370040]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: Observation and ACA data nominal; suspect processing issue
   - observation_id: 2018:158:10:17:36.762
     status: 1
     agasc_id: [738075032]
@@ -602,27 +602,27 @@ obs:
   - observation_id: 2019:248:14:52:31.156
     status: 1
     agasc_id: [759694976]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: NSM due to ACA high background during observation
   - observation_id: 2019:248:14:52:31.156
     status: 1
     agasc_id: [759696752]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: NSM due to ACA high background during observation
   - observation_id: 2019:248:14:52:31.156
     status: 1
     agasc_id: [759698088]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: NSM due to ACA high background during observation
   - observation_id: 2019:248:14:52:31.156
     status: 1
     agasc_id: [759701600]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: NSM due to ACA high background during observation
   - observation_id: 2006:212:07:39:07.107
     status: 1
     agasc_id: [763893760]
-    comments: Suspect observation
+    comments: Mostly tracking 11.6 mag star; supplement estimate is 13.8 mag
   - observation_id: 2011:285:11:34:00.061
     status: 1
     agasc_id: [764150080]
-    comments: Suspect observation
+    comments: Never acquired; set mag 12.0 +/- 0.1
   - observation_id: 2017:196:02:40:43.206
     status: 1
     agasc_id: [770973104]
@@ -634,7 +634,7 @@ obs:
   - observation_id: 2020:083:13:35:57.577
     status: 1
     agasc_id: [798760200]
-    comments: Suspect observation
+    comments: Never acquired; set mag 11.2 +/- 0.1
   - observation_id: 2010:089:12:06:07.502
     status: 1
     agasc_id: [805966472]
@@ -654,19 +654,19 @@ obs:
   - observation_id: 2020:145:13:55:06.000
     status: 1
     agasc_id: [844368576]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: Safe mode at start of observation
   - observation_id: 2020:145:13:55:06.000
     status: 1
     agasc_id: [844375152]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: Safe mode at start of observation
   - observation_id: 2020:145:13:55:06.000
     status: 1
     agasc_id: [845289720]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: Safe mode at start of observation
   - observation_id: 2020:145:13:55:06.000
     status: 1
     agasc_id: [845293880]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: Safe mode at start of observation
   - observation_id: 2003:357:02:49:14.852
     status: 1
     agasc_id: [857375576]
@@ -746,11 +746,11 @@ obs:
   - observation_id: 2013:312:22:02:15.039
     status: 1
     agasc_id: [898124000]
-    comments: Suspect observation
+    comments: Venus (should not be processed)
   - observation_id: 2013:312:22:02:15.039
     status: 1
     agasc_id: [898125104]
-    comments: Suspect observation
+    comments: Venus (should not be processed)
   - observation_id: 2013:313:03:14:15.039
     status: 1
     agasc_id: [898125104]
@@ -770,19 +770,19 @@ obs:
   - observation_id: 2014:207:06:36:50.665
     status: 1
     agasc_id: [910562920]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: NSM at start of observation
   - observation_id: 2014:207:06:36:50.665
     status: 1
     agasc_id: [910693856]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: NSM at start of observation
   - observation_id: 2014:207:06:36:50.665
     status: 1
     agasc_id: [911082032]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: NSM at start of observation
   - observation_id: 2014:207:06:36:50.665
     status: 1
     agasc_id: [911083616]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: NSM at start of observation
   - observation_id: 2014:207:06:36:50.665
     status: 1
     agasc_id: [911089528]
@@ -794,7 +794,7 @@ obs:
   - observation_id: 2014:244:14:47:42.617
     status: 1
     agasc_id: [915541320]
-    comments: Suspect observation
+    comments: Never acquired; set mag 11.6 +/- 0.1
   - observation_id: 2014:252:07:42:35.429
     status: 1
     agasc_id: [915939232]
@@ -818,19 +818,19 @@ obs:
   - observation_id: 2017:068:16:27:18.823
     status: 1
     agasc_id: [991169936]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: BSH at start of observation
   - observation_id: 2017:068:16:27:18.823
     status: 1
     agasc_id: [991175320]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: BSH at start of observation
   - observation_id: 2017:068:16:27:18.823
     status: 1
     agasc_id: [991564392]
-    comments: Mismatch in telemetry between aca_l0 and cheta
+    comments: BSH at start of observation
   - observation_id: 2007:130:19:34:45.821
     status: 1
     agasc_id: [1020796600]
-    comments: Suspect observation
+    comments: Never acquired; set mag 11.5 +/- 0.1
   - observation_id: 2011:343:07:05:57.421
     status: 1
     agasc_id: [1058938112]
@@ -838,7 +838,7 @@ obs:
   - observation_id: 2013:105:10:22:09.169
     status: 1
     agasc_id: [1081092600]
-    comments: Suspect observation
+    comments: Never acquired; set mag 11.0 +/- 0.1
   - observation_id: 2012:028:20:14:46.841
     status: 1
     agasc_id: [1092619768]
@@ -867,4 +867,46 @@ obs:
     status: 1
     agasc_id: [1178221128]
     comments: Suspect observation
-  
+mags:
+  - agasc_id: 1081092600
+    mag_aca: 11.0  # MAXMAG
+    mag_aca_err: 0.1
+  - agasc_id: 1020796600
+    mag_aca: 11.5  # MAXMAG
+    mag_aca_err: 0.1
+  - agasc_id: 915541320
+    mag_aca: 11.6  # MAXMAG
+    mag_aca_err: 0.1
+  - agasc_id: 798760200
+    mag_aca: 11.2  # MAXMAG
+    mag_aca_err: 0.1
+  - agasc_id: 764150080
+    mag_aca: 12.0  # MAXMAG
+    mag_aca_err: 0.1
+  - agasc_id: 693243160
+    mag_aca: 4.5  # Fabricated for too-bright star
+    mag_aca_err: 0.1
+  - agasc_id: 690625640
+    mag_aca: 11.2  # MAXMAG
+    mag_aca_err: 0.1
+  - agasc_id: 643702120
+    mag_aca: 11.4  # MAXMAG
+    mag_aca_err: 0.1
+  - agasc_id: 505545160
+    mag_aca: 10.8  # MAXMAG
+    mag_aca_err: 0.1
+  - agasc_id: 405271520
+    mag_aca: 11.2  # MAXMAG
+    mag_aca_err: 0.1
+  - agasc_id: 396501520
+    mag_aca: 10.3  # MAXMAG
+    mag_aca_err: 0.1
+  - agasc_id: 239080480
+    mag_aca: 10.2  # MAXMAG
+    mag_aca_err: 0.1
+  - agasc_id: 763893760
+    mag_aca: 11.6  # ACA estimate from mica
+    mag_aca_err: 0.1
+  - agasc_id: 723651200
+    mag_aca: 12.0  # ACA estimate
+    mag_aca_err: 0.1


### PR DESCRIPTION
## Description

This is a temporary PR for reviewing and merging obs-status dispositions over the mission, as submitted by each of the three ACA reviewers.

TA has done most of the AGASC IDs ending in `0`.  See 2319043 for the dispositions. I have not done it yet, but I think each of the stars that just has a lower limit for the magnitude (set to MAXMAG) should be included in the `bad` stars table.