### PR TITLE
Default dtype

### DIFF
--- a/agasc/supplement/utils.py
+++ b/agasc/supplement/utils.py
@@ -90,19 +90,22 @@ def get_supplement_table(name, agasc_dir=None, as_dict=False):
             dat = np.array([], dtype=dtypes[name])
 
     if as_dict:
-        out = {}
-        keys_names = {
-            'mags': ['agasc_id'],
-            'bad': ['agasc_id'],
-            'obs': ['agasc_id', 'mp_starcat_time']}
-        key_names = keys_names[name]
-        for row in dat:
-            # Make the key, coercing the values from numpy to native Python
-            key = tuple(row[nm].item() for nm in key_names)
-            if len(key) == 1:
-                key = key[0]
-            # Make the value from the remaining non-key column names
-            out[key] = {nm: row[nm].item() for nm in row.dtype.names if nm not in key_names}
+        if name in ['agasc_versions', 'last_updated']:
+            out = {name: dat[0][name] for name in dat.dtype.names} if len(dat) else {}
+        else:
+            out = {}
+            keys_names = {
+                'mags': ['agasc_id'],
+                'bad': ['agasc_id'],
+                'obs': ['agasc_id', 'mp_starcat_time']}
+            key_names = keys_names[name]
+            for row in dat:
+                # Make the key, coercing the values from numpy to native Python
+                key = tuple(row[nm].item() for nm in key_names)
+                if len(key) == 1:
+                    key = key[0]
+                # Make the value from the remaining non-key column names
+                out[key] = {nm: row[nm].item() for nm in row.dtype.names if nm not in key_names}
     else:
         out = Table(dat)
 

--- a/agasc/supplement/utils.py
+++ b/agasc/supplement/utils.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import logging
 import warnings
 import numpy as np
+from collections import defaultdict
 
 from ska_helpers.utils import lru_cache_timed
 import tables
@@ -74,6 +75,8 @@ def get_supplement_table(name, agasc_dir=None, as_dict=False):
     """
     agasc_dir = default_agasc_dir() if agasc_dir is None else Path(agasc_dir)
 
+    dtypes = defaultdict(lambda: [], {'bad': BAD_DTYPE, 'mags': MAGS_DTYPE, 'obs': OBS_DTYPE})
+
     if name not in AGASC_SUPPLEMENT_TABLES:
         raise ValueError(f"table name must be one of {AGASC_SUPPLEMENT_TABLES}")
 
@@ -84,7 +87,7 @@ def get_supplement_table(name, agasc_dir=None, as_dict=False):
         except tables.NoSuchNodeError:
             warnings.warn(f"No dataset '{name}' in {supplement_file},"
                           " returning empty table")
-            dat = []
+            dat = np.array([], dtype=dtypes[name])
 
     if as_dict:
         out = {}

--- a/agasc/supplement/utils.py
+++ b/agasc/supplement/utils.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import logging
 import warnings
 import numpy as np
-from collections import defaultdict
 
 from ska_helpers.utils import lru_cache_timed
 import tables
@@ -75,7 +74,7 @@ def get_supplement_table(name, agasc_dir=None, as_dict=False):
     """
     agasc_dir = default_agasc_dir() if agasc_dir is None else Path(agasc_dir)
 
-    dtypes = defaultdict(lambda: [], {'bad': BAD_DTYPE, 'mags': MAGS_DTYPE, 'obs': OBS_DTYPE})
+    dtypes = {'bad': BAD_DTYPE, 'mags': MAGS_DTYPE, 'obs': OBS_DTYPE}
 
     if name not in AGASC_SUPPLEMENT_TABLES:
         raise ValueError(f"table name must be one of {AGASC_SUPPLEMENT_TABLES}")
@@ -87,7 +86,7 @@ def get_supplement_table(name, agasc_dir=None, as_dict=False):
         except tables.NoSuchNodeError:
             warnings.warn(f"No dataset '{name}' in {supplement_file},"
                           " returning empty table")
-            dat = np.array([], dtype=dtypes[name])
+            dat = np.array([], dtype=dtypes.get(name, []))
 
     if as_dict:
         if name in ['agasc_versions', 'last_updated']:


### PR DESCRIPTION
## Description

This PR makes two changes:
- set default dtypes for supplement tables when they are not found in the file
- properly transform agasc_versions and last_updated tables into dictionaries in get_supplement_table

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing
   - starting from a supplement with no tables:
      ```
      from agasc import get_supplement_table, save_version
      get_supplement_table('mags', as_dict=False), get_supplement_table('agasc_versions', as_dict=True)
      ```
      gives
      ```                                                                                                                                
     /Users/javierg/SAO/git/agasc/agasc/supplement/utils.py:88: UserWarning: No dataset 'mags' in /Users/javierg/SAO/ska/data/agasc/agasc_supplement.h5, returning empty table
       warnings.warn(f"No dataset '{name}' in {supplement_file},"
     /Users/javierg/SAO/git/agasc/agasc/supplement/utils.py:88: UserWarning: No dataset 'agasc_versions' in /Users/javierg/SAO/ska/data/agasc/agasc_supplement.h5, returning empty table
       warnings.warn(f"No dataset '{name}' in {supplement_file},"
     Out[1]: 
     (<Table length=0>
      agasc_id mag_aca mag_aca_err last_obs_time
       int32   float32   float32      float64   
      -------- ------- ----------- -------------,
      {})
     ```
  - starting from a supplement with tables:
     ```
     from agasc import get_supplement_table, save_version
     get_supplement_table('agasc_versions', as_dict=True)
     ```
     gives
     ```
    {'mags': b'4.10.3.dev116+g2319043',
     'supplement': b'4.10.3.dev116+g2319043',
     'obs': b'4.10.3.dev116+g2319043'}

     ```
Fixes #