### PR TITLE
Skip processing if there are no observations to process

### DIFF
--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -442,7 +442,7 @@ def do(start,
                         {'status': r['status'], 'comments': r['comments']}
                     for r in obs_status_override
                 }
-            if 'mags' in h5.root:
+            if 'mags' in h5.root and len(stars_obs):
                 outliers_current = h5.root.mags[:]
                 times = stars_obs[['agasc_id', 'mp_starcat_time']].group_by(
                     'agasc_id').groups.aggregate(lambda d: np.max(CxoTime(d)).date)
@@ -472,6 +472,10 @@ def do(start,
                     if len(update) - np.sum(update):
                         logger.info(f'Skipping {len(update) - np.sum(update)} '
                                     f'stars already in the supplement')
+
+    if len(stars_obs) == 0:
+        logger.info(f'There are no new observations to process')
+        return
 
     # do the processing
     logger.info(f'Will process {len(agasc_ids)} stars on {len(stars_obs)} observations')

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -491,14 +491,18 @@ def do(start,
     failed_global = [f for f in fails if not f['agasc_id'] and not f['obsid']]
     failed_stars = [f for f in fails if f['agasc_id'] and not f['obsid']]
     failed_obs = [f for f in fails if f['obsid']]
-    logger.info(
+    msg = (
         f'Got:\n'
         f'  {0 if obs_stats is None else len(obs_stats)} OBSIDs,'
         f'  {0 if agasc_stats is None else len(agasc_stats)} stars,'
-        f'  {len(failed_stars)} failed stars,'
-        f'  {len(failed_obs)} failed observations,'
-        f'  {len(failed_global)} global errors'
     )
+    if failed_obs:
+        msg += f'  {len(failed_obs)} failed observations,'
+    if failed_stars:
+        msg += f'  {len(failed_stars)} failed stars,'
+    if failed_global:
+        msg += f'  {len(failed_global)} global errors'
+    logger.info(msg)
 
     if not output_dir.exists():
         output_dir.mkdir(parents=True)


### PR DESCRIPTION
## Description

This PR introduces three changes:
- Do not check the mags table in the supplement before updating, if there are no observations to begin with. This fixes issue #119 which is related to [this issue in astropy](https://github.com/astropy/astropy/issues/11884).
- Do not run if there are no observations to process. This fixes the case when one runs an update over a time range where all observations have been processed already, which would lead to a crash in line 234 of the same file.
- Do not include the words "fail" or "error" in the summary log message unless there was a failure or error. This prevents the automated log-checker to issue warnings when it sees this:
   ```Got  2653 OBSIDs,  158 stars,  0 failed stars,  0 failed observations,  0 global errors```

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing (checking that the log message is correct):
   - [x] Running update process as described in #119 with master and group-by-bug branches
   - [x] Running update on an interval already processed exits at the beginning


