### PR TITLE
add link to supplement diff in email notifications

### DIFF
--- a/task_schedules/task_schedule_supplement_dispositions.cfg
+++ b/task_schedules/task_schedule_supplement_dispositions.cfg
@@ -30,6 +30,9 @@ notify       aca@cfa.harvard.edu
 
   Logs:
   $ENV{SKA}/data/agasc/logs
+
+  Current diff:
+  https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement/agasc_supplement_diff.html
  NOTIFY
 
 # Define task parameters

--- a/task_schedules/task_schedule_update_supplement_rc.cfg
+++ b/task_schedules/task_schedule_update_supplement_rc.cfg
@@ -33,6 +33,9 @@ notify       aca@cfa.harvard.edu
 
   Obs-status file:
   $ENV{SKA}/data/agasc/rc/obs_status.yml
+
+  Current diff:
+  https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement/agasc_supplement_diff.html
 NOTIFY
 
 # Define task parameters


### PR DESCRIPTION
## Description

This PR adds a link to the supplement diff in update and disposition emails. Fixes #122

## Testing

- [ ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing

Fixes #