### PR TITLE
remove existing obs_status file if it is not going to be replaced

### DIFF
--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -335,6 +335,8 @@ def write_obs_status_yaml(obs_stats=None, fails=(), filename=None):
                 'comments': fail['msg']
             })
     if len(obs) == 0:
+        if filename and filename.exists():
+            filename.unlink()
         return
 
     yaml_template = """obs:


### PR DESCRIPTION
## Description

Currently, if there are no obs_status changes, nothing is done, and the file from the previous run is left there, which might be confusing. This PR removes and existing obs_status file if it is not going to be replaced.

## Testing

- [ ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing

Fixes #