### PR TITLE
Enhanced output obs_status to include maxmag

### DIFF
--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -348,7 +348,7 @@ def write_obs_status_yaml(obs_stats=None, fails=(), filename=None):
         else:
             agasc_ids += [(agasc_id, -1) for agasc_id in obs['agasc_id']]
 
-        agasc_ids = dict(sorted(agasc_ids))
+    agasc_ids = dict(sorted(agasc_ids))
 
     yaml_template = """bad:
   {%- for agasc_id, maxmag in agasc_ids.items() %}
@@ -372,10 +372,11 @@ obs:
   {%- endfor %}
   """
     tpl = jinja2.Template(yaml_template)
+    result = tpl.render(observations=obs, agasc_ids=agasc_ids)
     if filename:
         with open(filename, 'w') as fh:
-            fh.write(tpl.render(observations=obs, agasc_ids=agasc_ids))
-    return tpl.render(observations=obs)
+            fh.write(result)
+    return result
 
 
 def do(start,


### PR DESCRIPTION
## Description

Following the suggestion in issue #116, this PR enhances the output obs_status.yml file to include some standard information that is often needed anyway.

The main differences with the suggestion in #116:
- there is no string invalidating the yaml so it cannot be ingested by mistake.
- The default "bad" value is 0, which is not a value in the list.
- The default magnitude is the MAXMAG value for the observation.
- the comments are not set to 'Never acquired. Set mag to MAXMAG'.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing. I did the following using both the `master` version and the one in this PR:
     ```
     mkdir test-pr125
     cd test-pr125
     echo 5115672 > agasc_ids
     agasc-update-magnitudes --agasc-id-file agasc_ids
     ``` 
     with master I get the following yaml:
     ```
     obs:
       - mp_starcat_time: 2013:323:16:25:05.901
         obsid: 53222
         status: 1
         agasc_id: [5115672]
         comments: Suspect observation
     ```
     and with this branch I get:
     ```
     bad:
       5115672: 0
     mags:
     - agasc_id: 5115672
       mag_aca: 12.297
       mag_aca_err: 0.1
     obs:
     - agasc_id:
       - 5115672
       comments: Suspect observation
       mp_starcat_time: 2013:323:16:25:05.901
       obsid: 53222
       status: 1
     ```
     **Incidentally**... if you look into the current supplement, the magnitude is listed as 11.422, and the obs table says for this observation: "Faint star. Never acquired. Set mag to MAXMAG", but 11.422 is not the right value for MAXMAG for this specific observation. It is the MAXMAG in OBSID 8619, which is not currently flagged as suspect. The current version gives a magnitude of 12.623448 using OBSID 8619.

Fixes #116