### PR TITLE
Fix matplotlib ticks warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ _*
 *~
 supplement_reports
 test
+.idea

--- a/agasc/scripts/mag_estimate_report.py
+++ b/agasc/scripts/mag_estimate_report.py
@@ -36,6 +36,9 @@ def get_parser():
     parser.add_argument('--weekly-report',
                         help="Add links to navigate weekly reports.",
                         action='store_true', default=False)
+    parser.add_argument('--all-stars',
+                        help="Include all stars in the report, not just suspect.",
+                        action='store_true', default=False)
     return parser
 
 
@@ -59,7 +62,9 @@ def main():
         args.start = CxoTime(args.start)
 
     t = (obs_stats['mp_starcat_time'])
-    ok = (t < args.stop) & (t > args.start) & ~obs_stats['obs_ok']
+    ok = (t < args.stop) & (t > args.start)
+    if not args.all_stars:
+        ok &= ~obs_stats['obs_ok']
     stars = np.unique(obs_stats[ok]['agasc_id'])
     sections = [{
         'id': 'stars',

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -10,6 +10,7 @@ from email.mime.text import MIMEText
 import jinja2
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.ticker import FixedLocator
 from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
 from tqdm import tqdm
 from astropy import table
@@ -571,8 +572,8 @@ class MagEstimateReport:
         for i in range(len(ok)):
             ax.scatter(timeline['x'][ok[i]], ticks[i] * timeline['y'][ok[i]], s=4, marker='.',
                        color='k')
+        ax.yaxis.set_major_locator(FixedLocator(ticks))
         ax.set_yticklabels(labels)
-        ax.set_yticks(ticks)
         ax.set_ylim((-1, ticks[-1] + 1))
         ax.grid(True, axis='y', linestyle=':')
 


### PR DESCRIPTION
## Description

Change code to avoid the following matplotlib warning:
```
FixedFormatter should only be used together with FixedLocator
```

I also made the following changes:
- added a line to `.gitignore`
- added --all-stars option to agasc-magnitudes-report (if not given, the report includes only suspect stars)

## Interface impacts
None

## Testing


### Unit tests

- [x] Mac

Independent check of unit tests by @taldcroft 
- [x] Mac

### Functional tests

For testing, I added an option to the `agasc-magnitudes-report` (included in this PR) which causes the report to include all stars, not just the ones with suspect observations. I ran that script in both the `master` and `fix-warning` branches with the folllowing bash commands and looked at differences in the output:
```bash
git co fix-warning
cp agasc/scripts/mag_estimate_report.py .
python mag_estimate_report.py --start 2022:085:20:25:00 --output-dir fix-warning --all-stars
git co master
python mag_estimate_report.py --start 2022:085:20:25:00 --output-dir master --all-stars
for f in `find master -type f`; do echo ${f/master/fix-warning}; diff -u $f ${f/master/fix-warning}; done;
```

I could verify that:
- in `master` I got the warning whereas in `fix-warning` I did not.
- The output is the same.