### PR TITLE
fix breakage due to kadi 5.9.1 changing dtypes

### DIFF
--- a/agasc/supplement/magnitudes/star_obs_catalogs.py
+++ b/agasc/supplement/magnitudes/star_obs_catalogs.py
@@ -54,6 +54,7 @@ def _load_startcat_commands(tstop=None):
     global DWELLS_MAP
 
     STARCAT_CMDS = Table(get_cmds('2003:001', type='MP_STARCAT'))['date', 'timeline_id']
+    STARCAT_CMDS.convert_bytestring_to_unicode()
     STARCAT_CMDS.rename_column('date', 'mp_starcat_time')
     # print(len(starcat_cmds))
     STARCAT_CMDS = table.unique(STARCAT_CMDS, keys='mp_starcat_time')


### PR DESCRIPTION
## Description

Since kadi 5.9.1, mp_starcat_date is returned as bytestring instead of unicode string. This PR fixes that.

## Interface impacts
None

## Testing

### Unit tests
- [x] Mac

### Functional tests

The following code:
```python
from agasc.supplement.magnitudes.mag_estimate import get_agasc_id_stats
get_agasc_id_stats(869141880)
```
fails in current master with the error `KeyError: '2022:056:18:53:56.158'`

It succeeds after the change in this PR.
