### PR TITLE
More informative exception logging

### DIFF
--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -360,6 +360,9 @@ def get_telemetry(obs):
         (telem['AOACASEQ'] == 'KALM') & (telem['AOACIIR'] == 'OK') & \
         (telem['AOPCADMD'] == 'NPNT') & (telem['AOACFCT'] == 'TRAK')
 
+    assert len(slot_data) == len(mag_est_ok), \
+        f'len(slot_data) != len(ok) ({len(slot_data)} != {len(mag_est_ok)})'
+
     # etc...
     logger.debug('    Adding magnitude estimates')
     telem.update(get_mag_from_img(slot_data, start, mag_est_ok))

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -86,14 +86,12 @@ def get_agasc_id_stats(agasc_ids, obs_status_override={}, tstop=None, no_progres
             logger.debug(msg)
             fails.append(dict(mag_estimate.MagStatsException(agasc_id=agasc_id, msg=msg)))
             exc_type, exc_value, exc_traceback = sys.exc_info()
-            trace = traceback.extract_tb(exc_traceback)
             if exc_type is not None:
-                logger.debug(f"{exc_value}")
-                for step in trace:
-                    logger.debug(
-                        f"  in {step.filename}:{step.lineno}/{step.name}:"
-                    )
-                    logger.debug(f"    {step.line}")
+                trace = traceback.format_exception(exc_type, exc_value, exc_traceback)
+                for level in trace:
+                    for line in level.splitlines():
+                        logger.debug(line)
+                    logger.debug('')
 
     bar.close()
     logger.debug('-' * 80)

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import traceback
+import sys
 import warnings
 import os
 import pickle
@@ -83,6 +85,15 @@ def get_agasc_id_stats(agasc_ids, obs_status_override={}, tstop=None, no_progres
             msg = f'Unexpected Error: {e}'
             logger.debug(msg)
             fails.append(dict(mag_estimate.MagStatsException(agasc_id=agasc_id, msg=msg)))
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            trace = traceback.extract_tb(exc_traceback)
+            if exc_type is not None:
+                logger.debug(f"{exc_value}")
+                for step in trace:
+                    logger.debug(
+                        f"  in {step.filename}:{step.lineno}/{step.name}:"
+                    )
+                    logger.debug(f"    {step.line}")
 
     bar.close()
     logger.debug('-' * 80)
@@ -96,7 +107,6 @@ def get_agasc_id_stats(agasc_ids, obs_status_override={}, tstop=None, no_progres
         # transform Exception to MagStatsException for standard book keeping
         fails.append(dict(mag_estimate.MagStatsException(
             msg=f'Exception at end of get_agasc_id_stats: {str(e)}')))
-
     return obs_stats, agasc_stats, fails
 
 
@@ -232,7 +242,7 @@ def update_supplement(agasc_stats, filename, include_all=True):
         if False, only OK entries marked 'selected_*'
     :return:
     """
-    if len(agasc_stats) == 0:
+    if agasc_stats is None or len(agasc_stats) == 0:
         return [], []
 
     if include_all:


### PR DESCRIPTION
## Description

This PR makes changes so the stack trace is logged whenever an unexpected exception happens.

It also raises an exception in the case where the failure in issue #141 will occur.

## Interface impacts
None

## Testing

### Unit tests
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

I ran the supplement update in a way that causes an error in this branch:
```
echo 109584104 >> agasc_ids
python -m agasc.scripts.update_mag_supplement --agasc-id-file agasc_ids --log-level debug
```
and the output after this PR includes:
```
2022-11-03 09:35:09,919 Unexpected Error: len(slot_data) != len(ok) (20947 != 20946)
2022-11-03 09:35:09,920 Traceback (most recent call last):
2022-11-03 09:35:09,920 
2022-11-03 09:35:09,920   File "/Users/javierg/SAO/git/agasc/agasc/supplement/magnitudes/update_mag_supplement.py", line 73, in get_agasc_id_stats
2022-11-03 09:35:09,920     mag_estimate.get_agasc_id_stats(agasc_id=agasc_id,
2022-11-03 09:35:09,920 
2022-11-03 09:35:09,920   File "/Users/javierg/SAO/git/agasc/agasc/supplement/magnitudes/mag_estimate.py", line 1100, in get_agasc_id_stats
2022-11-03 09:35:09,920     telem = Table(get_telemetry(obs))
2022-11-03 09:35:09,920 
2022-11-03 09:35:09,920   File "/Users/javierg/SAO/git/agasc/agasc/supplement/magnitudes/mag_estimate.py", line 363, in get_telemetry
2022-11-03 09:35:09,920     assert len(slot_data) == len(mag_est_ok), \
2022-11-03 09:35:09,920 
2022-11-03 09:35:09,920 AssertionError: len(slot_data) != len(ok) (20947 != 20946)
```