### PR TITLE
Use union=True when filtering bad times in MSID set

### DIFF
--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -297,7 +297,9 @@ def get_telemetry(obs):
     names = ['AOACASEQ', 'AOPCADMD', 'CVCMJCTR', 'CVCMNCTR',
              f'AOACIIR{slot}', f'AOACISP{slot}', f'AOACMAG{slot}', f'AOACFCT{slot}',
              f'AOACZAN{slot}', f'AOACYAN{slot}'] + [f'AOATTQT{i}' for i in range(1, 5)]
-    msids = fetch.Msidset(names, start, stop)
+    # not using Msidset because that calls filter_bad with union=False
+    msids = fetch.MSIDset(names, start, stop)
+    msids.filter_bad(union=True)
     if len(slot_data) == 0:
         raise MagStatsException('No level 0 data',
                                 agasc_id=obs["agasc_id"],


### PR DESCRIPTION
This PR introduces a change to fix #141. That issue arised because there is an MSID set which had bad times that were different for different MSIDs. This behavior in MSIDset.filter_bad was introduced in Ska.engarchive version 4.57.0.

To fix it, we now use `fetch.MSIDset` instead of `fetch.Msidset` and directly call MSIDset.filter_bad with the `union=True` argument.

## Description

Fixes #141 

## Interface impacts
None

## Testing

### Unit tests
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

The following script fails before this PR and succeeds after:

```
from agasc.supplement.magnitudes import mag_estimate, star_obs_catalogs as cat
cat.load()
obs = cat.STARS_OBS[(cat.STARS_OBS['agasc_id'] == 109584104) & (cat.STARS_OBS['obsid'] == 5606)][0]
mag_estimate.get_telemetry(obs)
```
