### PR TITLE
Reduce peak memory use by not reading full file to get RA DEC columns

### DIFF
--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -119,14 +119,11 @@ class RaDec(object):
         return self._dec
 
     def read_ra_dec(self):
-        # Read the file of RA and DEC values (sorted on DEC):
-        #  dec: DEC values
-        #  ra: RA values
+        # Read the RA and DEC values from the agasc
         with tables.open_file(self.agasc_file) as h5:
-            radecs = h5.root.data[:][['RA', 'DEC']]
-
-            # Now copy to separate ndarrays for memory efficiency
-            return radecs['RA'].copy(), radecs['DEC'].copy()
+            ras = h5.root.data.read(field='RA')
+            decs = h5.root.data.read(field='DEC')
+        return ras, decs
 
 
 def get_ra_decs(agasc_file):


### PR DESCRIPTION
## Description
Reduce peak memory use by reading just the RA and DEC fields to get them (used for indexing into the agasc).


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac


Independent check of unit tests by @taldcroft:
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I looked at this before and after with memory profiler output and confirmed that the change means that, using the proseco agasc file as an example, only the 60Mb columns are read into memory instead of the file (which peaks more at ~600Mb).
