### PR TITLE
WIP: faster approximate spherical distance

### DIFF
--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -7,6 +7,7 @@ from packaging.version import Version
 from pathlib import Path
 from typing import Optional
 
+import numba
 import numexpr
 import numpy as np
 import tables
@@ -337,6 +338,21 @@ def get_agasc_filename(
     out = sorted(matches)[-1][1]
 
     return str(out)
+
+
+@numba.njit
+def sphere_dist_fast(ra1, dec1, ra2, dec2):
+    # Spherical distance between two points on a unit sphere.
+    ra1 = np.radians(ra1)
+    ra2 = np.radians(ra2)
+    dec1 = np.radians(dec1)
+    dec2 = np.radians(dec2)
+
+    dists = np.arccos(
+        np.sin(dec1) * np.sin(dec2)
+        + np.cos(dec1) * np.cos(dec2) * np.cos(ra1 - ra2)
+    )
+    return np.degrees(dists)
 
 
 def sphere_dist(ra1, dec1, ra2, dec2):


### PR DESCRIPTION
## Description

This is a WIP fast numba implementation of the spherical distance between two coordinates. It uses the spherical law of cosines formula, which is not very accurate is the distance is less than about 5 arcsec. (Ref:  https://en.wikipedia.org/wiki/Great-circle_distance says the cosines formula is inaccurate if the distance on the Earth is less than 1 km).

But sometimes (for instance in the AGASC cone search) we are more interested in getting the distance on scales of a degree.

This improves the speed by a factor of 2 for large arrays and a factor of 70 for numpy scalars.

(I just found this change in my `agasc` repo from a while ago).

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

#### Timing
```
import numpy as np
from agasc.agasc import sphere_dist, sphere_dist_fast

ra1 = np.float64(10)
dec1 = np.float64(10)

ra2 = np.random.uniform(-5, 5, size=1000) + ra1
dec2 = np.random.uniform(-5, 5, size=1000) + dec1

ra3 = np.float64(15)
dec3 = np.float64(15)
```
With 1000 elements:
```
%timeit sphere_dist(ra1, dec1, ra2, dec2)
69.5 µs ± 932 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
%timeit sphere_dist_fast(ra1, dec1, ra2, dec2)
29.1 µs ± 425 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```
With 1 element:
```
%timeit sphere_dist(ra1, dec1, ra3, dec3)
24.6 µs ± 317 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
%timeit sphere_dist_fast(ra1, dec1, ra3, dec3)
338 ns ± 1.77 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```
