### PR TITLE
Fix process failures

### DIFF
--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -1064,7 +1064,12 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
         'selected_atol': False,
         'selected_rtol': False,
         'selected_mag_aca_err': False,
-        'selected_color': False
+        'selected_color': False,
+        'f_mag_est_ok': 0,
+        'f_mag_est_ok_3': 0,
+        'f_mag_est_ok_5': 0,
+        'f_ok_3': 0,
+        'f_ok_5': 0,
     }
 
     for tag in ['dr3', 'dbox5']:

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -285,14 +285,16 @@ class MagEstimateReport:
                     "ignore",
                     message="Warning: converting a masked element to nan.",
                 )
-                out.write(run_template.render(info=info,
-                                            sections=sections,
-                                            failures=fails,
-                                            star_reports=star_reports,
-                                            nav_links=nav_links,
-                                            tooltips=tooltips,
-                                            static_dir=static_dir,
-                                            glossary=GLOSSARY))
+                out.write(run_template.render(
+                    info=info,
+                    sections=sections,
+                    failures=fails,
+                    star_reports=star_reports,
+                    nav_links=nav_links,
+                    tooltips=tooltips,
+                    static_dir=static_dir,
+                    glossary=GLOSSARY
+                ))
 
         json_filename = filename.replace('.html', '.json')
         if json_filename == filename:

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -243,7 +243,7 @@ class MagEstimateReport:
         star_reports = {}
         logger.debug('-' * 80)
         logger.info("Generating star reports")
-        for agasc_id in tqdm(np.atleast_1d(agasc_ids),
+        for agasc_id in tqdm(np.atleast_1d(agasc_ids).tolist(),
                              desc='progress', disable=no_progress, unit='star'):
             try:
                 logger.debug('-' * 80)

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -5,6 +5,7 @@ import errno
 import os
 import copy
 import json
+import warnings
 from subprocess import Popen, PIPE
 from pathlib import Path
 from email.mime.text import MIMEText
@@ -140,10 +141,17 @@ class MagEstimateReport:
         plt.close(fig)
 
         with open(directory / 'index.html', 'w') as out:
-            out.write(star_template.render(agasc_stats=agasc_stat,
-                                           obs_stats=obs_stat.as_array(),
-                                           static_dir=static_dir,
-                                           glossary=GLOSSARY))
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="Warning: converting a masked element to nan.",
+                )
+                out.write(star_template.render(
+                    agasc_stats=agasc_stat,
+                    obs_stats=obs_stat.as_array(),
+                    static_dir=static_dir,
+                    glossary=GLOSSARY)
+                )
         with open(directory / 'data.json', 'w') as json_out:
             json.dump(
                 {
@@ -272,14 +280,19 @@ class MagEstimateReport:
         if not self.directory.exists():
             self.directory.mkdir(parents=True)
         with open(self.directory / filename, 'w') as out:
-            out.write(run_template.render(info=info,
-                                          sections=sections,
-                                          failures=fails,
-                                          star_reports=star_reports,
-                                          nav_links=nav_links,
-                                          tooltips=tooltips,
-                                          static_dir=static_dir,
-                                          glossary=GLOSSARY))
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="Warning: converting a masked element to nan.",
+                )
+                out.write(run_template.render(info=info,
+                                            sections=sections,
+                                            failures=fails,
+                                            star_reports=star_reports,
+                                            nav_links=nav_links,
+                                            tooltips=tooltips,
+                                            static_dir=static_dir,
+                                            glossary=GLOSSARY))
 
         json_filename = filename.replace('.html', '.json')
         if json_filename == filename:

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -173,16 +173,21 @@ def get_agasc_id_stats_pool(agasc_ids, obs_status_override=None, batch_size=100,
 
 def _update_table(table_old, table_new, keys):
     # checking names, because actual types change upon saving in fits format
-    assert table_old.as_array().dtype.names == table_new.as_array().dtype.names, \
-        'Tables have different dtype'
+    if set(table_old.colnames) != set(table_new.colnames):
+        raise Exception(
+            'Tables have different columns:'
+            f'\n  {table_old.colnames}'
+            f'\n  {table_new.colnames}'
+        )
     table_old = table_old.copy()
     new_row = np.ones(len(table_new), dtype=bool)
     _, i_new, i_old = np.intersect1d(table_new[keys].as_array(),
                                      table_old[keys].as_array(),
                                      return_indices=True)
     new_row[i_new] = False
-    table_old[i_old] = table_new[i_new]
-    return table.vstack([table_old, table_new[new_row]])
+    columns = table_old.as_array().dtype.names
+    table_old[i_old] = table_new[i_new][columns]
+    return table.vstack([table_old, table_new[new_row][columns]])
 
 
 def update_mag_stats(obs_stats, agasc_stats, fails, outdir='.'):

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -674,6 +674,13 @@ def do(start,
         except Exception as e:
             report_dir = output_dir
             logger.error(f'Error when creating report: {e}')
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            if exc_type is not None:
+                trace = traceback.format_exception(exc_type, exc_value, exc_traceback)
+                for level in trace:
+                    for line in level.splitlines():
+                        logger.debug(line)
+                    logger.debug('')
         finally:
             report_data_file = report_dir / report_data_file.name
             if not report_dir.exists():


### PR DESCRIPTION
## Description

There might be better ways to fix the issues, but this works.

The changes are:
- Fix `Tables have different dtype` error when the first star in the list fails (#149). I checked, and this does not seem to be related with where in the function it fails (leading to dictionaries sorted differently). It might just be that the columns are sorted differently in the file. I do not care. The code should not care.
- Fix `keys must be str, int, float, bool or None, not int64` error (also with a failing star). This was caused by `np.atleast_1d` acting on a list of integers.
- Write the stack trace to the debug log in case of failure.
- Ignore the `converting a masked element to nan.` warning. An alternative would be to set the value to the column's fill value, but I think nan is ok.

Fixes #149 
Fixes #150

## Interface impacts
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux


Independent check of unit tests by Jean
- [x] Linux

### Functional tests

I ran the tests described in issues #149 and #150, and checked that both issues are fixed, and that the `converting a masked element to nan` warning is not issued.
