### PR TITLE
In agasc supplement processing, only process observations that already happened.

### DIFF
--- a/agasc/supplement/magnitudes/star_obs_catalogs.py
+++ b/agasc/supplement/magnitudes/star_obs_catalogs.py
@@ -6,7 +6,8 @@ from astropy.table import Table, join
 from astropy import table
 
 from chandra_aca.transform import yagzag_to_pixels
-from kadi import commands
+from kadi import commands, events
+from cxotime import CxoTime
 
 
 STARS_OBS = None
@@ -42,6 +43,9 @@ def get_star_observations(start=None, stop=None, obsid=None):
     star_obs = table.join(star_obs, tt, keys='agasc_id')
 
     star_obs.add_index(['mp_starcat_time'])
+
+    max_time = CxoTime(events.dwells.all().table[-1]['stop'])
+    star_obs = star_obs[star_obs['obs_start'] <= max_time]
 
     return star_obs
 

--- a/agasc/supplement/magnitudes/star_obs_catalogs.py
+++ b/agasc/supplement/magnitudes/star_obs_catalogs.py
@@ -7,7 +7,6 @@ from astropy import table
 
 from chandra_aca.transform import yagzag_to_pixels
 from kadi import commands, events
-from cxotime import CxoTime
 
 
 STARS_OBS = None
@@ -44,7 +43,7 @@ def get_star_observations(start=None, stop=None, obsid=None):
 
     star_obs.add_index(['mp_starcat_time'])
 
-    max_time = CxoTime(events.dwells.all().table[-1]['stop'])
+    max_time = events.dwells.all().latest('tstart').stop
     star_obs = star_obs[star_obs['obs_start'] <= max_time]
 
     return star_obs


### PR DESCRIPTION
## Description

To determine that an observation already happened, I use `kadi.events.dwells`. I only consider observations before the last dwell in `kadi.events`. This avoids the `No level 0 data` in weekly processing.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
As a quick test that this PR does "something", I did the following, which succeeds on this branch, but fails in current master (and is the cause of the `No level 0 data` error):
```
from mica.archive import aca_l0
from agasc.supplement.magnitudes import star_obs_catalogs as soc
from cxotime import CxoTime
soc.load()
i = np.argmax(CxoTime(soc.STARS_OBS['obs_start']))
aca_l0.get_files(soc.STARS_OBS['obsid'][i])
```
