### PR TITLE
Fix memory issue

### DIFF
--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -488,8 +488,8 @@ def get_telemetry_by_agasc_id(agasc_id, obsid=None, ignore_exceptions=False):
             (star_obs_catalogs.STARS_OBS["agasc_id"] == agasc_id)
             & (star_obs_catalogs.STARS_OBS["obsid"] == obsid)
         ]
-    if len(obs) > 1:
-        obs = obs.loc["mp_starcat_time", sorted(obs["mp_starcat_time"])]
+    obs.sort("mp_starcat_time")
+
     telem = []
     for _i, o in enumerate(obs):
         try:
@@ -1150,8 +1150,7 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
     star_obs = star_obs_catalogs.STARS_OBS[
         star_obs_catalogs.STARS_OBS["agasc_id"] == agasc_id
     ]
-    if len(star_obs) > 1:
-        star_obs = star_obs.loc["mp_starcat_time", sorted(star_obs["mp_starcat_time"])]
+    star_obs.sort("mp_starcat_time")
 
     # this is the default result, if nothing gets calculated
     result = {

--- a/agasc/supplement/magnitudes/star_obs_catalogs.py
+++ b/agasc/supplement/magnitudes/star_obs_catalogs.py
@@ -43,8 +43,6 @@ def get_star_observations(start=None, stop=None, obsid=None):
     tt = Table([agasc_ids, mag_errs], names=["agasc_id", "mag_aca_err"])
     star_obs = table.join(star_obs, tt, keys="agasc_id")
 
-    star_obs.add_index(["mp_starcat_time"])
-
     max_time = events.dwells.all().latest("tstart").stop
     star_obs = star_obs[star_obs["obs_start"] <= max_time]
 


### PR DESCRIPTION
## Description

remove index in STARS_OBS

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #156 

# Deployment

In addition to merging this PR to have the fix in future releases, this change will be deployed as a hot fix, replacing the following files:
```
agasc/supplement/magnitudes/mag_estimate.py
agasc/supplement/magnitudes/star_obs_catalogs.py
```
in 
```
/proj/sot/ska3/flight/lib/python3.10/site-packages/
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
=========================================================== test session starts ===========================================================
platform linux -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /proj/sot/ska/jgonzalez/git, configfile: pytest.ini
plugins: anyio-3.6.2, timeout-2.1.0
collected 72 items                                                                                                                        

agasc/tests/test_agasc_1.py .....                                                                                                   [  6%]
agasc/tests/test_agasc_2.py ..........................................                                                              [ 65%]
agasc/tests/test_agasc_healpix.py ...........                                                                                       [ 80%]
agasc/tests/test_obs_status.py ..............                                                                                       [100%]

====================================================== 72 passed in 88.74s (0:01:28) ======================================================

```

Independent check of unit tests by Jean
- [x] Linux ska3-flight 
```
ska3-jeanconn-fido> pytest
================================================== test session starts ===================================================
platform linux -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /proj/sot/ska/jeanproj/git, configfile: pytest.ini
plugins: anyio-3.6.2, timeout-2.1.0
collected 72 items                                                                                                       

agasc/tests/test_agasc_1.py .....                                                                                  [  6%]
agasc/tests/test_agasc_2.py ..........................................                                             [ 65%]
agasc/tests/test_agasc_healpix.py ...........                                                                      [ 80%]
agasc/tests/test_obs_status.py ..............                                                                      [100%]

============================================= 72 passed in 102.77s (0:01:42) =============================================
ska3-jeanconn-fido> git rev-parse HEAD
df798493077b61a5dac5f6d57c90efc52cf8839d
```

### Functional tests

I am running the agasc update using a small custom script that sets the input arguments directly from a file called `call_args.yml`. This file is automatically generated every week and can be found in `$SKA/data/agasc/rc`. I did make a small change in `call_args.yml`, I set `stop=2024:049:00:00:00.000`. Otherwise, the number of observations considered did not match what was considered in the weekly run.

The output of this script running on the branch was compared with the output currently in `$SKA/data/agasc/rc` (see below how to do it):
https://icxc.cfa.harvard.edu/aspect/test_review_outputs/agasc/pr-166//all/final/supplement_diff.html

The weekly report after running with the branch is here https://icxc.cfa.harvard.edu/aspect/test_review_outputs/agasc/pr-166/all/final/supplement_reports/weekly/latest/

This is how to get the diff between the two agasc supplements:
```
agasc-supplement-diff --from /proj/sot/ska/data/agasc/rc/agasc_supplement.h5 --to `pwd`/agasc_supplement.h5 -o supplement_diff.html
```

This is the script:
```python
#!/usr/bin/env python


import yaml
from agasc.supplement.magnitudes import update_mag_supplement, star_obs_catalogs
from pathlib import Path
from pprint import pprint
from cxotime import CxoTime
import pyyaks.logger


def main():
    pyyaks.logger.get_logger(
        name="agasc.supplement",
        level="DEBUG",
        format="%(asctime)s %(message)s",
    )

    args_log_file = "call_args.yml"
    with open(args_log_file, "r") as fh:
        args = yaml.load(fh, Loader=yaml.SafeLoader)

    args = {
        "output_dir": Path(args["output_dir"]),
        "reports_dir": Path(args["reports_dir"]),
        "report_date": CxoTime(args["report_date"]),
        "agasc_ids": args["agasc_ids"],
        "multi_process": args["multi_process"],
        "start": args["start"],
        "stop": args["stop"],
        "report": args["report"],
        "include_bad": args["include_bad"],
        "dry_run": args["dry_run"],
        "no_progress": args["no_progress"],
    }
    pprint(args)

    star_obs_catalogs.load(args['stop'])
    update_mag_supplement.do(**args)

if __name__ == "__main__":
    main()
```

Using this script, I determined that there was a memory problem:
![newplot](https://github.com/sot/agasc/assets/140523/45c3bdca-1042-4631-9ffd-08f11d2495f8)

and this is how the memory usage looks in the branch:
![newplot (5)](https://github.com/sot/agasc/assets/140523/41ae036e-64e2-424b-a346-6d54d440f447)




