### PR TITLE
Improve logging to make it easier to re-run with the same configuration

### DIFF
--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -172,8 +172,8 @@ def get_args():
             with open(args.agasc_id_file, "r") as f:
                 agasc_ids = [int(line.strip()) for line in f.readlines()]
 
-        # update 'bad' and 'obs' tables in supplement
-        agasc_ids += update_supplement.update(args)
+    # update 'bad' and 'obs' tables in supplement
+    agasc_ids += update_supplement.update(args)
 
     # set start/stop times
     if args.whole_history:

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -9,6 +9,7 @@ import argparse
 import logging
 import os
 from pathlib import Path
+from pprint import pformat
 
 import pyyaks.logger
 import yaml
@@ -112,8 +113,7 @@ def get_parser():
     return parser
 
 
-def main():
-
+def get_args():
     logger = logging.getLogger("agasc.supplement")
     the_parser = get_parser()
     args = the_parser.parse_args()
@@ -163,14 +163,17 @@ def main():
 
     star_obs_catalogs.load(args.stop)
 
-    # set the list of AGASC IDs from file if specified. If not, it will include all.
-    agasc_ids = []
-    if args.agasc_id_file:
-        with open(args.agasc_id_file, "r") as f:
-            agasc_ids = [int(line.strip()) for line in f.readlines()]
+    if "agasc_ids" in file_args:
+        agasc_ids = file_args["agasc_ids"]
+    else:
+        # set the list of AGASC IDs from file if specified. If not, it will include all.
+        agasc_ids = []
+        if args.agasc_id_file:
+            with open(args.agasc_id_file, "r") as f:
+                agasc_ids = [int(line.strip()) for line in f.readlines()]
 
-    # update 'bad' and 'obs' tables in supplement
-    agasc_ids += update_supplement.update(args)
+        # update 'bad' and 'obs' tables in supplement
+        agasc_ids += update_supplement.update(args)
 
     # set start/stop times
     if args.whole_history:
@@ -187,7 +190,9 @@ def main():
         )
 
     report_date = None
-    if args.report:
+    if "report_date" in file_args:
+        report_date = CxoTime(file_args["report_date"])
+    elif args.report:
         report_date = CxoTime(args.stop)
         # the nominal date for reports is the first Monday after the stop date.
         # this is not perfect, because it needs to agree with nav_links in update_mag_supplement.do
@@ -197,29 +202,49 @@ def main():
     args_log_file = args.output_dir / "call_args.yml"
     if not args.output_dir.exists():
         args.output_dir.mkdir(parents=True)
+
+    # there must be a better way to do this...
+    yaml_args = {
+        k: str(v) if issubclass(type(v), Path) else v for k, v in vars(args).items()
+    }
+    yaml_args["report_date"] = report_date.date
+    yaml_args["agasc_ids"] = agasc_ids
     with open(args_log_file, "w") as fh:
-        # there must be a better way to do this...
-        yaml_args = {
-            k: str(v) if issubclass(type(v), Path) else v for k, v in vars(args).items()
-        }
         yaml.dump(yaml_args, fh)
 
-    update_mag_supplement.do(
-        output_dir=args.output_dir,
-        reports_dir=args.reports_dir,
-        report_date=report_date,
-        agasc_ids=agasc_ids if agasc_ids else None,
-        multi_process=args.multi_process,
-        start=args.start,
-        stop=args.stop,
-        report=args.report,
-        include_bad=args.include_bad,
-        dry_run=args.dry_run,
-        no_progress=args.no_progress,
-    )
-    if args.report and (args.reports_dir / f"{report_date.date[:8]}").exists():
+    logger.info("Input arguments")
+    for line in pformat(yaml_args).split("\n"):
+        logger.info(line.rstrip())
+
+    return {
+        "output_dir": args.output_dir,
+        "reports_dir": args.reports_dir,
+        "report_date": report_date,
+        "agasc_ids": agasc_ids if agasc_ids else None,
+        "multi_process": args.multi_process,
+        "start": args.start,
+        "stop": args.stop,
+        "report": args.report,
+        "include_bad": args.include_bad,
+        "dry_run": args.dry_run,
+        "no_progress": args.no_progress,
+        "args_log_file": args_log_file,
+    }
+
+
+def main():
+
+    args = get_args()
+    args_log_file = args.pop("args_log_file")
+
+    update_mag_supplement.do(**args)
+
+    if (
+        args["report"]
+        and (args["reports_dir"] / f"{args['report_date'].date[:8]}").exists()
+    ):
         args_log_file.replace(
-            args.reports_dir / f"{report_date.date[:8]}" / args_log_file.name
+            args["reports_dir"] / f"{args['report_date'].date[:8]}" / args_log_file.name
         )
 
 

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -199,7 +199,7 @@ def get_args():
         report_date += ((7 - report_date.datetime.weekday()) % 7) * u.day
         report_date = CxoTime(report_date.date[:8])
 
-    args_log_file = args.output_dir / "call_args.yml"
+    args_log_file = get_next_file_name(args.output_dir / "call_args.yml")
     if not args.output_dir.exists():
         args.output_dir.mkdir(parents=True)
 
@@ -209,6 +209,7 @@ def get_args():
     }
     yaml_args["report_date"] = report_date.date
     yaml_args["agasc_ids"] = agasc_ids
+    logger.info(f"Writing input arguments to {args_log_file}")
     with open(args_log_file, "w") as fh:
         yaml.dump(yaml_args, fh)
 
@@ -230,6 +231,17 @@ def get_args():
         "no_progress": args.no_progress,
         "args_log_file": args_log_file,
     }
+
+
+def get_next_file_name(file_name):
+    if not file_name.exists():
+        return file_name
+    i = 1
+    while True:
+        new_file_name = file_name.with_suffix(f".{i}{file_name.suffix}")
+        if not new_file_name.exists():
+            return new_file_name
+        i += 1
 
 
 def main():

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -615,6 +615,20 @@ def do(
     # do the processing
     logger.info(f"Will process {len(agasc_ids)} stars on {len(stars_obs)} observations")
     logger.info(f"from {start} to {stop}")
+
+    obs_times = CxoTime(star_obs_catalogs.STARS_OBS["mp_starcat_time"])
+    latest = np.sort(
+        np.unique(
+            star_obs_catalogs.STARS_OBS[["mp_starcat_time", "obsid"]][
+                obs_times > obs_times.max() - 1 * u.day
+            ]
+        )
+    )[-10:]
+    logger.info("latest observations:")
+    for row in latest:
+        logger.info(
+            f"  mp_starcat_time: {row['mp_starcat_time']}, OBSID {row['obsid']}"
+        )
     if dry_run:
         return
 


### PR DESCRIPTION
## Description

This PR introduces changes that make it easier to run the weekly agasc supplement update script with the same input arguments. This was motivated by #166 

The current master version has all of the required features, except that the report date is not captured in the log file. With this PR, the report date is also included in the log.

As a convenience the list of AGASC IDs given to the script is also added to the log (also not kept in the log in the masters version).

Also added a few logging messages.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by Jean
- [x] Linux

```
ska3-jeanconn-fido> pytest
============================= test session starts ==============================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 72 items                                                                                                                

agasc/tests/test_agasc_1.py .....                                                                                           [  6%]
agasc/tests/test_agasc_2.py ..........................................                                                      [ 65%]
agasc/tests/test_agasc_healpix.py ...........                                                                               [ 80%]
agasc/tests/test_obs_status.py ..............                                                                               [100%]

================================================= 72 passed in 118.58s (0:01:58) ==================================================
ska3-jeanconn-fido> git rev-parse HEAD
4811f585cb067968426daa5672180e3067813d86
```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

Follow these steps to run with the same arguments as last weeks processing:
```
mkdir pr-168
cd pr-168
cp /proj/sot/ska/data/agasc/rc/supplement_reports/weekly/latest/call_args.yml .
echo report_date: 2024:092:00:00:00.000 >> call_args.yml
# NOTE: edit call_args.yml to change output_dir and reports_dir so it does not overwrite stuff in $SKA/data
python -m agasc.scripts.update_mag_supplement --args-file call_args.yml
```