### PR TITLE
Fix DEC order comparison issue in test_agasc_healpix.py

### DIFF
--- a/agasc/tests/test_agasc_healpix.py
+++ b/agasc/tests/test_agasc_healpix.py
@@ -52,6 +52,15 @@ def test_get_functions_dec_order_vs_healpix(ra, dec):
     stars_healpix = agasc.get_agasc_cone(
         ra, dec, radius=0.2, agasc_file=agasc_healpix, date="2023:001"
     )
+
+    # See https://github.com/sot/agasc/issues/169.
+    assert len(stars_dec) == len(stars_healpix)
+    # Make sure that both versions have DEC in ascending order.
+    assert np.all(np.diff(stars_dec["DEC"]) >= 0)
+    assert np.all(np.diff(stars_healpix["DEC"]) >= 0)
+    # Now lexically sort in-place by DEC and AGASC_ID and compare.
+    stars_dec.sort(["DEC", "AGASC_ID"])
+    stars_healpix.sort(["DEC", "AGASC_ID"])
     assert np.all(stars_dec == stars_healpix)
 
     agasc_ids = stars_dec["AGASC_ID"]


### PR DESCRIPTION
## Description

This fixes a test to run more reliably on all platforms (specifically fido). See the discussion in #169 for details. 

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #169

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2024.0rc9) ➜  agasc git:(fix-healpix-ordering-test) git rev-parse HEAD   
fd9b5f793152098c1a8f64f04144c18831b27915
(ska3-flight-2024.0rc9) ➜  agasc git:(fix-healpix-ordering-test) pytest
============================================================= test session starts =============================================================
platform darwin -- Python 3.11.7, pytest-7.4.4, pluggy-1.3.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.2.0
collected 72 items                                                                                                                            

agasc/tests/test_agasc_1.py .....                                                                                                       [  6%]
agasc/tests/test_agasc_2.py ..........sssss..........ss...............                                                                  [ 65%]
agasc/tests/test_agasc_healpix.py ...........                                                                                           [ 80%]
agasc/tests/test_obs_status.py ..............                                                                                           [100%]

======================================================== 65 passed, 7 skipped in 9.88s ========================================================
```

Independent check of unit tests by @jeanconn:
- [x] linux on fido - confirmed first that I could reproduce the previous failure in master and then no failure in this PR code

```
(ska3-masters) jeanconn-fido> export SKA=/proj/sot/ska
(ska3-masters) jeanconn-fido> pytest -k healpix
============================= test session starts ==============================
platform linux -- Python 3.11.7, pytest-7.4.4, pluggy-1.3.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.2.0
collected 72 items / 61 deselected / 11 selected                                                                           

agasc/tests/test_agasc_healpix.py .....F.....                                                                        [100%]

========================================================= FAILURES =========================================================
_____________________________ test_get_functions_dec_order_vs_healpix[80.0--4.444444444444443] _____________________________

ra = 80.0, dec = -4.444444444444443

    @pytest.mark.skipif(
        AGASC_FILES["agasc_healpix_*", "1p7"] is None,
        reason="No AGASC 1.7 HEALpix file found",
    )
    @pytest.mark.parametrize("ra, dec", zip(ras, decs))
    def test_get_functions_dec_order_vs_healpix(ra, dec):
        # AGASC 1p7 is dec-ordered.
        agasc_dec = agasc.get_agasc_filename("agasc*", version="1p7")
        agasc_healpix = agasc.get_agasc_filename("agasc_healpix_*", version="1p7")
        stars_dec = agasc.get_agasc_cone(
            ra, dec, radius=0.2, agasc_file=agasc_dec, date="2023:001"
        )
    
        stars_healpix = agasc.get_agasc_cone(
            ra, dec, radius=0.2, agasc_file=agasc_healpix, date="2023:001"
        )
>       assert np.all(stars_dec == stars_healpix)
E       assert False
E        +  where False = <function all at 0x7ff606fc6bf0>(<Table length...701   -4.25606 == <Table length...701   -4.25606
E        +    where <function all at 0x7ff606fc6bf0> = np.all
E           Use -v to get more diff)

agasc/tests/test_agasc_healpix.py:55: AssertionError
================================================= short test summary info ==================================================
FAILED agasc/tests/test_agasc_healpix.py::test_get_functions_dec_order_vs_healpix[80.0--4.444444444444443] - assert False
======================================= 1 failed, 10 passed, 61 deselected in 36.07s =======================================
(ska3-masters) jeanconn-fido> git rev-parse HEAD
befb07b3413d01749af0ad2a3d74cbc2fff257ed
(ska3-masters) jeanconn-fido> git fetch
Enter passphrase for key '/home/jeanconn/.ssh/id_rsa': 
remote: Enumerating objects: 5, done.
remote: Counting objects: 100% (5/5), done.
remote: Total 5 (delta 4), reused 5 (delta 4), pack-reused 0
Unpacking objects: 100% (5/5), 697 bytes | 2.00 KiB/s, done.
From github.com:sot/agasc
 * [new branch]      fix-healpix-ordering-test -> origin/fix-healpix-ordering-test
(ska3-masters) jeanconn-fido> git checkout fix-healpix-ordering-test
branch 'fix-healpix-ordering-test' set up to track 'origin/fix-healpix-ordering-test'.
Switched to a new branch 'fix-healpix-ordering-test'
(ska3-masters) jeanconn-fido> git rev-parse HEAD
fd9b5f793152098c1a8f64f04144c18831b27915
(ska3-masters) jeanconn-fido> pytest -k healpix
=================================================== test session starts ====================================================
platform linux -- Python 3.11.7, pytest-7.4.4, pluggy-1.3.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.2.0
collected 72 items / 61 deselected / 11 selected                                                                           

agasc/tests/test_agasc_healpix.py ...........                                                                        [100%]

============================================ 11 passed, 61 deselected in 34.06
(ska3-masters) jeanconn-fido> pytest
=================================================== test session starts ====================================================
platform linux -- Python 3.11.7, pytest-7.4.4, pluggy-1.3.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.2.0
collected 72 items                                                                                                         

agasc/tests/test_agasc_1.py .....                                                                                    [  6%]
agasc/tests/test_agasc_2.py ..........................................                                               [ 65%]
agasc/tests/test_agasc_healpix.py ...........                                                                        [ 80%]
agasc/tests/test_obs_status.py ..............                                                                        [100%]

============================================== 72 passed in 84.10s (0:01:24)
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
