### PR TITLE
Remove statements forcing use of kadi commands v1

### DIFF
--- a/agasc/scripts/mag_estimate_report.py
+++ b/agasc/scripts/mag_estimate_report.py
@@ -76,9 +76,6 @@ def get_parser():
 
 
 def main():
-    import kadi.commands
-
-    kadi.commands.conf.commands_version = "1"
 
     args = get_parser().parse_args()
 

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -199,7 +199,7 @@ def get_args():
         report_date += ((7 - report_date.datetime.weekday()) % 7) * u.day
         report_date = CxoTime(report_date.date[:8])
 
-    args_log_file = args.output_dir / "call_args.yml"
+    args_log_file = get_next_file_name(args.output_dir / "call_args.yml")
     if not args.output_dir.exists():
         args.output_dir.mkdir(parents=True)
 
@@ -209,6 +209,7 @@ def get_args():
     }
     yaml_args["report_date"] = report_date.date
     yaml_args["agasc_ids"] = agasc_ids
+    logger.info(f"Writing input arguments to {args_log_file}")
     with open(args_log_file, "w") as fh:
         yaml.dump(yaml_args, fh)
 
@@ -231,6 +232,16 @@ def get_args():
         "args_log_file": args_log_file,
     }
 
+
+def get_next_file_name(file_name):
+    if not file_name.exists():
+        return file_name
+    i = 1
+    while True:
+        new_file_name = file_name.with_suffix(f".{i}{file_name.suffix}")
+        if not new_file_name.exists():
+            return new_file_name
+        i += 1
 
 def main():
     import kadi.commands

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -231,6 +231,7 @@ def get_args():
         args_log_file=args_log_file,
     )
 
+
 def main():
     import kadi.commands
 
@@ -241,7 +242,10 @@ def main():
 
     update_mag_supplement.do(**args)
 
-    if args["report"] and (args["reports_dir"] / f"{args['report_date'].date[:8]}").exists():
+    if (
+        args["report"]
+        and (args["reports_dir"] / f"{args['report_date'].date[:8]}").exists()
+    ):
         args_log_file.replace(
             args["reports_dir"] / f"{args['report_date'].date[:8]}" / args_log_file.name
         )

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -244,9 +244,6 @@ def get_next_file_name(file_name):
         i += 1
 
 def main():
-    import kadi.commands
-
-    kadi.commands.conf.commands_version = "1"
 
     args = get_args()
     args_log_file = args.pop("args_log_file")

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -216,20 +216,20 @@ def get_args():
     for line in pformat(yaml_args).split("\n"):
         logger.info(line.rstrip())
 
-    return dict(
-        output_dir=args.output_dir,
-        reports_dir=args.reports_dir,
-        report_date=report_date,
-        agasc_ids=agasc_ids if agasc_ids else None,
-        multi_process=args.multi_process,
-        start=args.start,
-        stop=args.stop,
-        report=args.report,
-        include_bad=args.include_bad,
-        dry_run=args.dry_run,
-        no_progress=args.no_progress,
-        args_log_file=args_log_file,
-    )
+    return {
+        "output_dir": args.output_dir,
+        "reports_dir": args.reports_dir,
+        "report_date": report_date,
+        "agasc_ids": agasc_ids if agasc_ids else None,
+        "multi_process": args.multi_process,
+        "start": args.start,
+        "stop": args.stop,
+        "report": args.report,
+        "include_bad": args.include_bad,
+        "dry_run": args.dry_run,
+        "no_progress": args.no_progress,
+        "args_log_file": args_log_file,
+    }
 
 
 def main():

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -243,6 +243,7 @@ def get_next_file_name(file_name):
             return new_file_name
         i += 1
 
+
 def main():
 
     args = get_args()

--- a/agasc/scripts/update_supplement.py
+++ b/agasc/scripts/update_supplement.py
@@ -291,9 +291,6 @@ def main():
     """
     The main function for the update_obs_status script.
     """
-    import kadi.commands
-
-    kadi.commands.conf.commands_version = "1"
 
     args = get_parser().parse_args()
 

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -488,8 +488,8 @@ def get_telemetry_by_agasc_id(agasc_id, obsid=None, ignore_exceptions=False):
             (star_obs_catalogs.STARS_OBS["agasc_id"] == agasc_id)
             & (star_obs_catalogs.STARS_OBS["obsid"] == obsid)
         ]
-    if len(obs) > 1:
-        obs = obs.loc["mp_starcat_time", sorted(obs["mp_starcat_time"])]
+    obs.sort("mp_starcat_time")
+
     telem = []
     for _i, o in enumerate(obs):
         try:
@@ -1150,8 +1150,7 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
     star_obs = star_obs_catalogs.STARS_OBS[
         star_obs_catalogs.STARS_OBS["agasc_id"] == agasc_id
     ]
-    if len(star_obs) > 1:
-        star_obs = star_obs.loc["mp_starcat_time", sorted(star_obs["mp_starcat_time"])]
+    star_obs.sort("mp_starcat_time")
 
     # this is the default result, if nothing gets calculated
     result = {

--- a/agasc/supplement/magnitudes/star_obs_catalogs.py
+++ b/agasc/supplement/magnitudes/star_obs_catalogs.py
@@ -43,8 +43,6 @@ def get_star_observations(start=None, stop=None, obsid=None):
     tt = Table([agasc_ids, mag_errs], names=["agasc_id", "mag_aca_err"])
     star_obs = table.join(star_obs, tt, keys="agasc_id")
 
-    star_obs.add_index(["mp_starcat_time"])
-
     max_time = events.dwells.all().latest("tstart").stop
     star_obs = star_obs[star_obs["obs_start"] <= max_time]
 

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -617,14 +617,18 @@ def do(
     logger.info(f"from {start} to {stop}")
 
     obs_times = CxoTime(star_obs_catalogs.STARS_OBS["mp_starcat_time"])
-    latest = np.sort(np.unique(
-        star_obs_catalogs.STARS_OBS[["mp_starcat_time", "obsid"]][
-            obs_times > obs_times.max() - 1*u.day
-        ]
-    ))[-10:]
+    latest = np.sort(
+        np.unique(
+            star_obs_catalogs.STARS_OBS[["mp_starcat_time", "obsid"]][
+                obs_times > obs_times.max() - 1 * u.day
+            ]
+        )
+    )[-10:]
     logger.info("latest observations:")
     for row in latest:
-        logger.info(f"  mp_starcat_time: {row['mp_starcat_time']}, OBSID {row['obsid']}")
+        logger.info(
+            f"  mp_starcat_time: {row['mp_starcat_time']}, OBSID {row['obsid']}"
+        )
     if dry_run:
         return
 

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -615,6 +615,16 @@ def do(
     # do the processing
     logger.info(f"Will process {len(agasc_ids)} stars on {len(stars_obs)} observations")
     logger.info(f"from {start} to {stop}")
+
+    obs_times = CxoTime(star_obs_catalogs.STARS_OBS["mp_starcat_time"])
+    latest = np.sort(np.unique(
+        star_obs_catalogs.STARS_OBS[["mp_starcat_time", "obsid"]][
+            obs_times > obs_times.max() - 1*u.day
+        ]
+    ))[-10:]
+    logger.info("latest observations:")
+    for row in latest:
+        logger.info(f"  mp_starcat_time: {row['mp_starcat_time']}, OBSID {row['obsid']}")
     if dry_run:
         return
 


### PR DESCRIPTION
## Description

This PR removes a few statements in top-level scripts that are forcing the use of kadi commands v1.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
