### PR TITLE
generate a diff file with differences between supplements

### DIFF
--- a/agasc/scripts/supplement_diff.py
+++ b/agasc/scripts/supplement_diff.py
@@ -109,9 +109,9 @@ def table_diff(file_from, file_to):
     )
     for name in table_names:
         if hasattr(mags[f"mag_aca_{name}"], "mask"):
-            mags[f"mag_aca_{name}"][mags[f"mag_aca_{name}"].mask] = mags[
-                "mag_aca"
-            ][mags[f"mag_aca_{name}"].mask]
+            mags[f"mag_aca_{name}"][mags[f"mag_aca_{name}"].mask] = mags["mag_aca"][
+                mags[f"mag_aca_{name}"].mask
+            ]
 
     mags = table.join(mags, bad, join_type="outer")
 
@@ -122,8 +122,10 @@ def table_diff(file_from, file_to):
 
     # now we select the rows that changed
     mag_changed = (
-        (mags[f"mag_aca_{table_names[0]}"] != mags[f"mag_aca_{table_names[1]}"])
-        | (mags[f"bad_star_source_{table_names[0]}"] != mags[f"bad_star_source_{table_names[1]}"])
+        mags[f"mag_aca_{table_names[0]}"] != mags[f"mag_aca_{table_names[1]}"]
+    ) | (
+        mags[f"bad_star_source_{table_names[0]}"]
+        != mags[f"bad_star_source_{table_names[1]}"]
     )
     for name in table_names:
         if hasattr(mags[f"mag_aca_{name}"], "mask"):

--- a/agasc/scripts/supplement_diff.py
+++ b/agasc/scripts/supplement_diff.py
@@ -17,6 +17,8 @@ import tables
 from astropy import table
 from astropy.io import ascii
 
+import agasc
+
 
 def read_file(filename, exclude=None):
     if exclude is None:
@@ -66,6 +68,79 @@ def diff_to_html(diff):
     return pygments.highlight(diff, lexer, formatter)
 
 
+def table_diff(file_from, file_to):
+    table_names = ["from", "to"]
+    agasc_filename = agasc.get_agasc_filename()
+    with tables.open_file(agasc_filename) as h5:
+        stars = table.Table(h5.root.data[:])
+    stars.rename_columns(["AGASC_ID", "MAG_ACA"], ["agasc_id", "mag_aca"])
+
+    with tables.open_file(file_from) as h5_from, tables.open_file(file_to) as h5_to:
+        mags = table.join(
+            table.Table(h5_from.get_node("/mags")[:]),
+            table.Table(h5_to.get_node("/mags")[:]),
+            join_type="outer",
+            table_names=table_names,
+            keys="agasc_id",
+            metadata_conflicts="silent",
+        )
+        # the `bad` table will be joined with the `mags` table.
+        # I rename the columns so the names are self-explanatory.
+        b1 = table.Table(h5_from.get_node("/bad")[:])
+        b1.rename_column("source", "bad_star_source")
+        b2 = table.Table(h5_to.get_node("/bad")[:])
+        b2.rename_column("source", "bad_star_source")
+        bad = table.join(
+            b1,
+            b2,
+            join_type="outer",
+            table_names=table_names,
+            keys="agasc_id",
+            metadata_conflicts="silent",
+        )
+
+    # missing magnitudes in the supplement are filled with catalog magnitudes
+    mags = table.join(
+        mags,
+        stars[["agasc_id", "mag_aca"]],
+        keys="agasc_id",
+        join_type="left",
+        metadata_conflicts="silent",
+    )
+    for name in table_names:
+        if hasattr(mags[f"mag_aca_{name}"], "mask"):
+            mags[f"mag_aca_{name}"][mags[f"mag_aca_{name}"].mask] = mags[
+                "mag_aca"
+            ][mags[f"mag_aca_{name}"].mask]
+
+    mags = table.join(mags, bad, join_type="outer")
+
+    # filling remaining masked values so they can be compared
+    for name in table_names:
+        mags[f"bad_star_source_{name}"][mags[f"bad_star_source_{name}"].mask] = -9999
+        mags[f"mag_aca_{name}"][mags[f"mag_aca_{name}"].mask] = -9999
+
+    # now we select the rows that changed
+    mag_changed = (
+        (mags[f"mag_aca_{table_names[0]}"] != mags[f"mag_aca_{table_names[1]}"])
+        | (mags[f"bad_star_source_{table_names[0]}"] != mags[f"bad_star_source_{table_names[1]}"])
+    )
+    for name in table_names:
+        if hasattr(mags[f"mag_aca_{name}"], "mask"):
+            mag_changed |= mags[f"mag_aca_{name}"].mask
+
+    mags = mags[mag_changed]
+
+    mags["d_mag"] = (
+        mags[f"mag_aca_{table_names[1]}"] - mags[f"mag_aca_{table_names[0]}"]
+    )
+    mags["d_mag_err"] = (
+        mags[f"mag_aca_err_{table_names[1]}"] - mags[f"mag_aca_err_{table_names[0]}"]
+    )
+
+    return mags
+
+
 def get_parser():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -104,11 +179,15 @@ def main():
     if not args.o.parent.exists():
         args.o.parent.mkdir()
 
-    with open(args.o, "w") as fh:
-        diff = diff_to_html(
-            diff_files(args.fromfile, args.tofile, exclude_mags=args.exclude_mags)
-        )
-        fh.write(diff)
+    if args.o.suffix == ".html":
+        with open(args.o, "w") as fh:
+            diff = diff_to_html(
+                diff_files(args.fromfile, args.tofile, exclude_mags=args.exclude_mags)
+            )
+            fh.write(diff)
+    else:
+        mags = table_diff(args.fromfile, args.tofile)
+        mags.write(args.o, overwrite=True)
 
 
 if __name__ == "__main__":

--- a/agasc/scripts/supplement_tasks.py
+++ b/agasc/scripts/supplement_tasks.py
@@ -25,18 +25,18 @@ from agasc.scripts import supplement_diff
 AGASC_DATA = Path(os.environ["SKA"]) / "data" / "agasc"
 SENDER = f"{getpass.getuser()}@{platform.uname()[1]}"
 
-
-def email_promotion_report(filenames, destdir, to, sender=SENDER):
-    date = CxoTime().date[:14]
-    filenames = "  - " + "\n  - ".join([str(f) for f in filenames])
-
-    msg = MIMEText(f"""The following files were promoted to {destdir} on {date}:
+TEXT = """The following files were promoted to {destdir} on {date}:
 {filenames}
 
 The corresponding changes are documented at
     https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement/agasc_supplement_diff.ecsv
 """
-    )
+
+def email_promotion_report(filenames, destdir, to, sender=SENDER):
+    date = CxoTime().date[:14]
+    filenames = "  - " + "\n  - ".join([str(f) for f in filenames])
+
+    msg = MIMEText(TEXT.format(destdir=destdir, date=date, filenames=filenames))
     msg["From"] = sender
     msg["To"] = to
     msg["Subject"] = "AGASC RC supplement promoted"

--- a/agasc/scripts/supplement_tasks.py
+++ b/agasc/scripts/supplement_tasks.py
@@ -50,14 +50,15 @@ def update_rc():
     Update the supplement in $SKA/data/agasc/rc
     """
     filenames = list((AGASC_DATA / "rc" / "promote").glob("*"))
-    diff = supplement_diff.table_diff(
-        AGASC_DATA / "agasc_supplement.h5",
-        AGASC_DATA / "rc" / "promote" / "agasc_supplement.h5",
-    )
-    diff.write(
-        "/proj/sot/ska/www/ASPECT/agasc/supplement/agasc_supplement_diff.ecsv",
-        overwrite=True,
-    )
+    if (AGASC_DATA / "rc" / "promote" / "agasc_supplement.h5").exists():
+        diff = supplement_diff.table_diff(
+            AGASC_DATA / "agasc_supplement.h5",
+            AGASC_DATA / "rc" / "promote" / "agasc_supplement.h5",
+        )
+        diff.write(
+            "/proj/sot/ska/www/ASPECT/agasc/supplement/agasc_supplement_diff.ecsv",
+            overwrite=True,
+        )
     if filenames:
         for file in filenames:
             file.rename(AGASC_DATA / file.name)

--- a/agasc/scripts/supplement_tasks.py
+++ b/agasc/scripts/supplement_tasks.py
@@ -32,6 +32,7 @@ The corresponding changes are documented at
     https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement/agasc_supplement_diff.ecsv
 """
 
+
 def email_promotion_report(filenames, destdir, to, sender=SENDER):
     date = CxoTime().date[:14]
     filenames = "  - " + "\n  - ".join([str(f) for f in filenames])

--- a/agasc/scripts/supplement_tasks.py
+++ b/agasc/scripts/supplement_tasks.py
@@ -56,7 +56,7 @@ def update_rc():
             AGASC_DATA / "rc" / "promote" / "agasc_supplement.h5",
         )
         diff.write(
-            "/proj/sot/ska/www/ASPECT/agasc/supplement/agasc_supplement_diff.ecsv",
+            f"{os.environ['SKA']}/www/ASPECT/agasc/supplement/agasc_supplement_diff.ecsv",
             overwrite=True,
         )
     if filenames:

--- a/agasc/scripts/supplement_tasks.py
+++ b/agasc/scripts/supplement_tasks.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 from cxotime import CxoTime
 
+from agasc.scripts import supplement_diff
+
 AGASC_DATA = Path(os.environ["SKA"]) / "data" / "agasc"
 SENDER = f"{getpass.getuser()}@{platform.uname()[1]}"
 
@@ -29,7 +31,12 @@ def email_promotion_report(filenames, destdir, to, sender=SENDER):
     filenames = "- " + "\n- ".join([str(f) for f in filenames])
 
     msg = MIMEText(
-        f"The following files were promoted to {destdir} on {date}:\n{filenames}"
+        f"""
+        The following files were promoted to {destdir} on {date}:\n{filenames}
+
+        The corresponding changes are documented at
+        https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement/agasc_supplement_diff.ecsv
+        """
     )
     msg["From"] = sender
     msg["To"] = to
@@ -43,6 +50,14 @@ def update_rc():
     Update the supplement in $SKA/data/agasc/rc
     """
     filenames = list((AGASC_DATA / "rc" / "promote").glob("*"))
+    diff = supplement_diff.table_diff(
+        AGASC_DATA / "agasc_supplement.h5",
+        AGASC_DATA / "rc" / "promote" / "agasc_supplement.h5",
+    )
+    diff.write(
+        "/proj/sot/ska/www/ASPECT/agasc/supplement/agasc_supplement_diff.ecsv",
+        overwrite=True,
+    )
     if filenames:
         for file in filenames:
             file.rename(AGASC_DATA / file.name)

--- a/agasc/scripts/supplement_tasks.py
+++ b/agasc/scripts/supplement_tasks.py
@@ -28,15 +28,14 @@ SENDER = f"{getpass.getuser()}@{platform.uname()[1]}"
 
 def email_promotion_report(filenames, destdir, to, sender=SENDER):
     date = CxoTime().date[:14]
-    filenames = "- " + "\n- ".join([str(f) for f in filenames])
+    filenames = "  - " + "\n  - ".join([str(f) for f in filenames])
 
-    msg = MIMEText(
-        f"""
-        The following files were promoted to {destdir} on {date}:\n{filenames}
+    msg = MIMEText(f"""The following files were promoted to {destdir} on {date}:
+{filenames}
 
-        The corresponding changes are documented at
-        https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement/agasc_supplement_diff.ecsv
-        """
+The corresponding changes are documented at
+    https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement/agasc_supplement_diff.ecsv
+"""
     )
     msg["From"] = sender
     msg["To"] = to


### PR DESCRIPTION
This PR adds functionality to generate an ECSV file with the (effective) differences between supplements.

I say "effective" because, if a star is not in the supplement, then the catalog magnitude is used, so strictly speaking it is not just the difference between supplements. It is the difference in magnitude reported by agasc when using the supplement.

## Description


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Provides a new data file intended to be used by other groups (sot mp).

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->

Independent check of unit tests by Jean
- [x] Mac

```
(ska3) flame:agasc jean$ pytest
==================================================== test session starts =====================================================
platform darwin -- Python 3.10.8, pytest-8.0.2, pluggy-1.4.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-3.6.2
collected 72 items                                                                                                           

agasc/tests/test_agasc_1.py .....                                                                                      [  6%]
agasc/tests/test_agasc_2.py ..........sssss..........ss...............                                                 [ 65%]
agasc/tests/test_agasc_healpix.py ...........                                                                          [ 80%]
agasc/tests/test_obs_status.py ..............                                                                          [100%]

=============================================== 65 passed, 7 skipped in 13.57s ===============================================
(ska3) flame:agasc jean$ git rev-parse HEAD
9575fc9f068361d3b236385152d0218b2c23a49c
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

#### Testing the diffs

Comparing between flight and RC:
```
python -m agasc.scripts.supplement_diff --from $SKA/data/agasc/agasc_supplement.h5 --to $SKA/data/agasc/rc/agasc_supplement.h5 -o agasc_supplement_diff.ecsv
```

Comparing when there are no diffs:
```
python -m agasc.scripts.supplement_diff --from $SKA/data/agasc/agasc_supplement.h5 --to $SKA/data/agasc/agasc_supplement.h5 -o empty.ecsv
```

#### Testing sending email

From the local repo:
```
export PYTHONPATH=`pwd`
mkdir -p ska/www/ASPECT/agasc/supplement
mkdir -p ska/data/agasc/rc/promote
ln -s $SKA/data/* ska/data/
cp $SKA/data/agasc/* ska/data/agasc/
export SKA=`pwd`/ska
cp ska/data/agasc/agasc_supplement.h5 ska/data/agasc/rc/promote
python -m agasc.scripts.supplement_tasks update-rc
```

This script fails in the last step (updating the supplement in rc) but does everything in the PR.