### PR TITLE
Don't use file_args if args_file not supplied

### DIFF
--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -163,7 +163,7 @@ def get_args():
 
     star_obs_catalogs.load(args.stop)
 
-    if "agasc_ids" in file_args:
+    if args.args_file and "agasc_ids" in file_args:
         agasc_ids = file_args["agasc_ids"]
     else:
         # set the list of AGASC IDs from file if specified. If not, it will include all.
@@ -190,7 +190,7 @@ def get_args():
         )
 
     report_date = None
-    if "report_date" in file_args:
+    if args.args_file and "report_date" in file_args:
         report_date = CxoTime(file_args["report_date"])
     elif args.report:
         report_date = CxoTime(args.stop)


### PR DESCRIPTION
## Description
Don't use file_args if args_file not supplied

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #176 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
(ska3-masters) jeanconn-fido> pytest
============================= test session starts ==============================
platform linux -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 72 items                                                                                                               

agasc/tests/test_agasc_1.py .....                                                                                          [  6%]
agasc/tests/test_agasc_2.py ..........................................                                                     [ 65%]
agasc/tests/test_agasc_healpix.py ...........                                                                              [ 80%]
agasc/tests/test_obs_status.py ..............                                                                              [100%]

================================================= 72 passed in 145.52s (0:02:25) =================================================
(ska3-masters) jeanconn-fido> git rev-parse HEAD
c2eace969576ea892047d7c85efcd98bc087f8e9
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Repeat of what we are seeing in flight
```
ska3-jeanconn-fido> agasc-update-magnitudes --log-level debug --output-dir /proj/sot/ska/www/ASPECT_ICXC/test_review_outputs/agasc/file_args --report
Traceback (most recent call last):
  File "/proj/sot/ska3/flight/bin/agasc-update-magnitudes", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/proj/sot/ska3/flight/lib/python3.11/site-packages/agasc/scripts/update_mag_supplement.py", line 249, in main
    args = get_args()
           ^^^^^^^^^^
  File "/proj/sot/ska3/flight/lib/python3.11/site-packages/agasc/scripts/update_mag_supplement.py", line 166, in get_args
    if "agasc_ids" in file_args:
                      ^^^^^^^^^
UnboundLocalError: cannot access local variable 'file_args' where it is not associated with a value
```

With this PR
```
(ska3-masters) jeanconn-fido> agasc-update-magnitudes --log-level debug --output-dir /proj/sot/ska/www/ASPECT_ICXC/test_review_outputs/agasc/agasc-pr177/ --report
... <lots of processing stuff > ...
saving /proj/sot/ska/www/ASPECT_ICXC/test_review_outputs/agasc/agasc-pr177/supplement_reports/weekly/2024:141/stars/120/1201411288/mag_stats.png                                                                                            progress: 100%|███████████████████████████| 696/696 [1:19:30<00:00,  6.85s/star]                                      2024-05-15 18:32:16,173 Creating "latest" symlink                                                                     2024-05-15 18:32:16,176 Report data saved in /proj/sot/ska/www/ASPECT_ICXC/test_review_outputs/agasc/agasc-pr177/supplement_reports/weekly/2024:141/report_data_2024:141.pkl                                                                2024-05-15 18:32:16,176 done at 2024-05-15 18:32:16.176658                  
```
with output to https://icxc.cfa.harvard.edu/aspect/test_review_outputs/agasc/agasc-pr177/supplement_reports/weekly/latest/ 