### PR TITLE
Fix create_derived_agasc_h5 to work for proseco_agasc

### DIFF
--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -609,7 +609,7 @@ def test_write(tmp_path):
         assert "healpix_index" not in h5_out.root
         assert h5_out.root.data.attrs["version"] == "test"
         assert h5_out.root.data.attrs["NROWS"] == 1000
-        assert h5_out.root.data.dtype == agasc.TABLE_DTYPE
+        assert h5_out.root.data.dtype == np.dtype(agasc.TABLE_DTYPES)
         assert np.all(np.diff(h5_out.root.data[:]["DEC"]) >= 0)
 
     write_agasc(temp, stars=stars, version="test")
@@ -618,4 +618,4 @@ def test_write(tmp_path):
         assert "healpix_index" in h5_out.root
         assert h5_out.root.data.attrs["version"] == "test"
         assert h5_out.root.data.attrs["NROWS"] == 1000
-        assert h5_out.root.data.dtype == agasc.TABLE_DTYPE
+        assert h5_out.root.data.dtype == agasc.TABLE_DTYPES

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -27,10 +27,12 @@ from pathlib import Path
 import numpy as np
 import pytest
 import Ska.Shell
+import tables
 from astropy.io import ascii
 from astropy.table import Row, Table
 
 import agasc
+from agasc import write_agasc
 
 os.environ[agasc.SUPPLEMENT_ENABLED_ENV] = "False"
 
@@ -583,24 +585,21 @@ def test_get_supplement_table_obs_dict():
     assert isinstance(obs, dict)
 
 
-def test_write(tmp_path):
-    from pathlib import Path
-
-    import tables
-
-    from agasc import write_agasc
-
+@pytest.fixture(scope="module")
+def stars_in():
     with tables.open_file(
         Path(os.environ["SKA"]) / "data" / "agasc" / "agasc1p7.h5"
     ) as h5_in:
-        stars = Table(h5_in.root.data[:1000])
+        stars_in = Table(h5_in.root.data[:1000])
 
-    # this is an extra column that should not make it to the output
-    stars["extra_col"] = np.arange(1000)
-    # channging these column types, which should then be fixed on writing
-    stars["AGASC_ID"] = stars["AGASC_ID"].astype(np.int64)
-    stars["MAG_ACA"] = stars["MAG_ACA"].astype(np.float64)
-    stars = stars.as_array()
+    return stars_in
+
+
+def test_write_munge_types(tmp_path, stars_in):
+    # changing these column types, which should then be fixed on writing
+    stars_in["AGASC_ID"] = stars_in["AGASC_ID"].astype(np.int64)
+    stars_in["MAG_ACA"] = stars_in["MAG_ACA"].astype(np.float64)
+    stars = stars_in.as_array()
 
     temp = tmp_path / "test.h5"
     write_agasc(temp, stars=stars, version="test", order=agasc.TableOrder.DEC)
@@ -609,7 +608,7 @@ def test_write(tmp_path):
         assert "healpix_index" not in h5_out.root
         assert h5_out.root.data.attrs["version"] == "test"
         assert h5_out.root.data.attrs["NROWS"] == 1000
-        assert h5_out.root.data.dtype == np.dtype(agasc.TABLE_DTYPES)
+        assert h5_out.root.data.dtype == agasc.TABLE_DTYPE
         assert np.all(np.diff(h5_out.root.data[:]["DEC"]) >= 0)
 
     write_agasc(temp, stars=stars, version="test")
@@ -618,4 +617,27 @@ def test_write(tmp_path):
         assert "healpix_index" in h5_out.root
         assert h5_out.root.data.attrs["version"] == "test"
         assert h5_out.root.data.attrs["NROWS"] == 1000
-        assert h5_out.root.data.dtype == agasc.TABLE_DTYPES
+        assert h5_out.root.data.dtype == agasc.TABLE_DTYPE
+
+
+@pytest.mark.parametrize("full_agasc", [True, False])
+def test_write_extra_column(tmp_path, stars_in, full_agasc):
+    temp = tmp_path / "test.h5"
+    # this is an extra column that should not make it to the output
+    stars_in["extra_col"] = np.arange(len(stars_in))
+    stars = stars_in.as_array()
+    with pytest.raises(ValueError, match=r"stars has disallowed keys: {'extra_col'}"):
+        write_agasc(temp, stars=stars, version="test", full_agasc=full_agasc)
+    del stars_in["extra_col"]
+
+
+def test_write_missing_column(tmp_path, stars_in):
+    temp = tmp_path / "test.h5"
+    del stars_in["MAG_ACA"]
+    stars = stars_in.as_array()
+
+    with pytest.raises(ValueError, match=r"missing keys in stars: {'MAG_ACA'}"):
+        write_agasc(temp, stars=stars, version="test")
+
+    # OK for full_agasc=False
+    write_agasc(temp, stars=stars, version="test", full_agasc=False)

--- a/create_derived_agasc_h5.py
+++ b/create_derived_agasc_h5.py
@@ -28,9 +28,9 @@ Examples
   $ python create_derived_agasc_h5.py proseco_agasc --version 1.8 \
       --filter-faint --include-near-neighbors --proseco-columns
   $ python create_derived_agasc_h5.py miniagasc --version 1.8 --filter-faint
+  $ python create_derived_agasc_h5.py miniagasc --version 1.7 --filter-faint --dec-order
   $ python create_derived_agasc_h5.py agasc_healpix --version 1.7
 """
-
 
 import argparse
 from pathlib import Path
@@ -86,9 +86,9 @@ def get_parser():
     return parser
 
 
-def main():
+def main(args_sys=None):
     parser = get_parser()
-    args = parser.parse_args()
+    args = parser.parse_args(args_sys)
 
     version_num = args.version
     version = version_num.replace(".", "p")
@@ -116,7 +116,14 @@ def main():
             "and sort by healpix index"
         )
 
-    write_agasc(filename_derived, stars, version, nside=args.nside, order=order)
+    write_agasc(
+        filename_derived,
+        stars,
+        version,
+        nside=args.nside,
+        order=order,
+        full_agasc=not args.proseco_columns,
+    )
 
 
 def filter_proseco_columns(stars):

--- a/create_near_neighbor_ids.py
+++ b/create_near_neighbor_ids.py
@@ -8,9 +8,8 @@ of AGASC IDs corresponding to all stars in AGASC 1.7 that are within
 This takes a while to run and should be done on a computer with copy
 of AGASC 1.7 on a local (fast) drive.
 
-Usage::
-
-  $ python create_near_neighbor_ids.py --version=1p7
+This creates an output file like ``agasc<version>_near_neighbor_ids.fits.gz`` which can
+be used by ``create_derived_agasc_h5.py`` to include near neighbors.
 """
 import argparse
 from pathlib import Path
@@ -23,7 +22,7 @@ import agasc
 
 
 def get_parser():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(__doc__)
     parser.add_argument(
         "agasc_full",
         type=str,


### PR DESCRIPTION
## Description

`create_derived_agasc_h5` was broken when trying to create a proseco_agasc file. The logic to check that all standard columns were available does not apply in this case.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds new argument `full_agasc` to `write_agasc()`. If true (default), require exactly the standard AGASC column names and dtypes. If false, ensure that the output columns are a strict subset of the standard AGASC columns.

This also adds a new `sys_args` argument to `main()`. This helped out with debugging at one point and I left it in.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  agasc git:(fix-create-derived-h5) pytest                       
=================================================== test session starts ===================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 75 items                                                                                                        

agasc/tests/test_agasc_1.py .....                                                                                   [  6%]
agasc/tests/test_agasc_2.py ..........sssss..........ss..................                                           [ 66%]
agasc/tests/test_agasc_healpix.py ...........                                                                       [ 81%]
agasc/tests/test_obs_status.py ..............                                                                       [100%]

============================================== 68 passed, 7 skipped in 7.92s ==============================================
(ska3) ➜  agasc git:(fix-create-derived-h5) git rev-parse HEAD                                             
abf213d98c2d5f66d614776b52dce8393cd50871
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Created a `miniagasc_1p7.h5` and `proseco_agasc_1p7.h5` with the updated code and confirmed that the output files had identical data content.
```
python create_derived_agasc_h5.py miniagasc --version 1.7 --filter-faint --dec-order
python create_derived_agasc_h5.py proseco_agasc --version 1.7 --filter-faint --include-near-neighbors \\
  --proseco-columns --dec-order
```
#### miniagasc
```
In [2]: import tables
   ...: 
   ...: h5 = tables.open_file("/Users/aldcroft/ska/data/agasc/miniagasc_1p7.h5")
   ...: agasc_flt = h5.root.data[:]
   ...: h5.close()
   ...: with tables.open_file("miniagasc_1p7.h5") as h5:
   ...:     agasc_new = h5.root.data[:]
   ...: len(agasc_flt)
   ...: len(agasc_new)
   ...: np.all(agasc_flt == agasc_new)
   ...: 
Out[2]: True
```
#### proseco agasc
```In [1]: import tables
   ...: 
   ...: with tables.open_file("/Users/aldcroft/ska/data/agasc/proseco_agasc_1p7.h5") as h5:
   ...:     agasc_flt = h5.root.data[:]
   ...: with tables.open_file("proseco_agasc_1p7.h5") as h5:
   ...:     agasc_new = h5.root.data[:]
   ...: np.all(agasc_flt == agasc_new)
   ...: 
Out[1]: True
```

