### PR TITLE
Fix tests to work with AGASC 1.8

### DIFF
--- a/agasc/tests/conftest.py
+++ b/agasc/tests/conftest.py
@@ -3,6 +3,16 @@ import pytest
 import agasc
 
 
+@pytest.fixture(autouse=True)
+def unset_agasc_hdf5_file_env(monkeypatch):
+    """Unset external AGASC_HDF5_FILE environment variable.
+
+    This fixture is before proseco_agasc_1p7 to ensure that the AGASC_HDF5_FILE
+    environment variable is not set by default.
+    """
+    monkeypatch.delenv("AGASC_HDF5_FILE", raising=False)
+
+
 @pytest.fixture()
 def proseco_agasc_1p7(monkeypatch):
     agasc_file = agasc.get_agasc_filename("proseco_agasc_*", version="1p7")

--- a/agasc/tests/conftest.py
+++ b/agasc/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+import agasc
+
+
+@pytest.fixture()
+def proseco_agasc_1p7(monkeypatch):
+    agasc_file = agasc.get_agasc_filename("proseco_agasc_*", version="1p7")
+    monkeypatch.setenv("AGASC_HDF5_FILE", agasc_file)

--- a/agasc/tests/test_agasc_1.py
+++ b/agasc/tests/test_agasc_1.py
@@ -20,9 +20,23 @@ def test_multi_agasc():
     with tables.open_file(agasc.default_agasc_file()) as h5:
         middle = int(len(h5.root.data) // 2)
         stars1 = Table(h5.root.data[middle : middle + 20])
-        stars1.write(os.path.join(tempdir, "stars1.h5"), path="data")
+        agasc.write_agasc(
+            os.path.join(tempdir, "stars1.h5"),
+            stars=stars1.as_array(),
+            version="test",
+            order=agasc.TableOrder.DEC,
+            full_agasc=False,
+        )
+        # stars1.write(os.path.join(tempdir, "stars1.h5"), path="data")
         stars2 = Table(h5.root.data[middle + 20 : middle + 60])
-        stars2.write(os.path.join(tempdir, "stars2.h5"), path="data")
+        agasc.write_agasc(
+            os.path.join(tempdir, "stars2.h5"),
+            stars=stars2.as_array(),
+            version="test",
+            order=agasc.TableOrder.DEC,
+            full_agasc=False,
+        )
+        # stars2.write(os.path.join(tempdir, "stars2.h5"), path="data")
 
     # Fetch all the stars from a custom agasc and make sure we have the right number of stars
     # with no errors
@@ -77,7 +91,7 @@ def test_update_color1_func():
     assert np.allclose(stars["COLOR2"], color2)
 
 
-def test_update_color1_get_star():
+def test_update_color1_get_star(proseco_agasc_1p7):
     """
     Test updated color1 in get_star() call.
 
@@ -101,7 +115,7 @@ def test_update_color1_get_star():
     assert np.isclose(star["COLOR1"], 1.5)
 
 
-def test_update_color1_get_agasc_cone():
+def test_update_color1_get_agasc_cone(proseco_agasc_1p7):
     """
     Test updated color1 in get_agasc_cone() call.
     """
@@ -118,6 +132,7 @@ def test_update_color1_get_agasc_cone():
 
 
 def test_get_agasc_filename(tmp_path, monkeypatch):
+    monkeypatch.delenv("AGASC_HDF5_FILE", raising=False)
     monkeypatch.setenv("AGASC_DIR", str(tmp_path))
     names = [
         "agasc1p6.h5",

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -126,8 +126,8 @@ else:
     else:
         TEST_ASCDS = True
 
-# Latest full release of miniagasc
-MINIAGASC = agasc.get_agasc_filename("miniagasc_*")
+# Version 1.7 of miniagasc
+MINIAGASC_1P7 = agasc.get_agasc_filename("miniagasc_*", version="1p7")
 
 
 def get_ds_agasc_cone(ra, dec):
@@ -420,10 +420,10 @@ def test_proseco_agasc_1p7():
 def test_supplement_get_agasc_cone():
     ra, dec = 282.53, -0.38  # Obsid 22429 with a couple of color1=1.5 stars
     stars1 = agasc.get_agasc_cone(
-        ra, dec, date="2021:001", agasc_file=MINIAGASC, use_supplement=False
+        ra, dec, date="2021:001", agasc_file=MINIAGASC_1P7, use_supplement=False
     )
     stars2 = agasc.get_agasc_cone(
-        ra, dec, date="2021:001", agasc_file=MINIAGASC, use_supplement=True
+        ra, dec, date="2021:001", agasc_file=MINIAGASC_1P7, use_supplement=True
     )
     ok = stars2["MAG_CATID"] == agasc.MAG_CATID_SUPPLEMENT
 
@@ -461,8 +461,8 @@ def test_supplement_get_star():
     agasc_id = 58720672
     # Also checks that the default is False given the os.environ override for
     # this test file.
-    star1 = agasc.get_star(agasc_id, agasc_file=MINIAGASC)
-    star2 = agasc.get_star(agasc_id, agasc_file=MINIAGASC, use_supplement=True)
+    star1 = agasc.get_star(agasc_id, agasc_file=MINIAGASC_1P7)
+    star2 = agasc.get_star(agasc_id, agasc_file=MINIAGASC_1P7, use_supplement=True)
     assert star1["MAG_CATID"] != agasc.MAG_CATID_SUPPLEMENT
     assert star2["MAG_CATID"] == agasc.MAG_CATID_SUPPLEMENT
 
@@ -504,8 +504,8 @@ def test_supplement_get_star_disable_decorator():
 @pytest.mark.skipif(NO_MAGS_IN_SUPPLEMENT, reason="no mags in supplement")
 def test_supplement_get_stars():
     agasc_ids = [58720672, 670303120]
-    star1 = agasc.get_stars(agasc_ids, agasc_file=MINIAGASC)
-    star2 = agasc.get_stars(agasc_ids, agasc_file=MINIAGASC, use_supplement=True)
+    star1 = agasc.get_stars(agasc_ids, agasc_file=MINIAGASC_1P7)
+    star2 = agasc.get_stars(agasc_ids, agasc_file=MINIAGASC_1P7, use_supplement=True)
     assert np.all(star1["MAG_CATID"] != agasc.MAG_CATID_SUPPLEMENT)
     assert np.all(star2["MAG_CATID"] == agasc.MAG_CATID_SUPPLEMENT)
 

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -533,13 +533,13 @@ def test_get_supplement_table_bad_dict():
 
 
 @agasc.set_supplement_enabled(True)
-def test_get_bad_star_with_supplement():
+def test_get_bad_star_with_supplement(proseco_agasc_1p7):
     agasc_id = 797847184
     star = agasc.get_star(agasc_id, use_supplement=True)
     assert star["CLASS"] == agasc.BAD_CLASS_SUPPLEMENT
 
 
-def test_bad_agasc_supplement_env_var():
+def test_bad_agasc_supplement_env_var(proseco_agasc_1p7):
     try:
         os.environ[agasc.SUPPLEMENT_ENABLED_ENV] = "asdfasdf"
         with pytest.raises(ValueError, match="env var must be either"):


### PR DESCRIPTION
## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes tests so that they pass with AGASC 1.8 available as the default flight AGASC.

Fixes #159

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->
Made a new local directory `agasc_test_1p8` with a symlink of every file in `$SKA/data/agasc`.  In that directory I made two more symlinks `agasc1p8.h5 -> agasc1p8rc11.h5` and `proseco_agasc_1p8.h5 -> proseco_agasc_1p8rc11.h5`.

Without this patch there are 3 tests that fail for the AGASC 1.8 case.

With this patch:
```
(ska3) ➜  agasc git:(fix-tests-for-agasc1p8) env AGASC_DIR=$PWD/agasc_test_1p8 AGASC_HDF5_FILE=junk pytest
====================================================== test session starts ======================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 75 items                                                                                                              

agasc/tests/test_agasc_1.py .....                                                                                         [  6%]
agasc/tests/test_agasc_2.py ..........sssss..........ss..................                                                 [ 66%]
agasc/tests/test_agasc_healpix.py ...........                                                                             [ 81%]
agasc/tests/test_obs_status.py ..............                                                                             [100%]

================================================= 68 passed, 7 skipped in 7.06s =================================================
(ska3) ➜  agasc git:(fix-tests-for-agasc1p8) env AGASC_DIR=$SKA/data/agasc AGASC_HDF5_FILE=junk pytest 
====================================================== test session starts ======================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 75 items                                                                                                              

agasc/tests/test_agasc_1.py .....                                                                                         [  6%]
agasc/tests/test_agasc_2.py ..........sssss..........ss..................                                                 [ 66%]
agasc/tests/test_agasc_healpix.py ...........                                                                             [ 81%]
agasc/tests/test_obs_status.py ..............                                                                             [100%]

================================================= 68 passed, 7 skipped in 7.93s =================================================
(ska3) ➜  agasc git:(fix-tests-for-agasc1p8) git rev-parse HEAD  
99493884f148f779fe196b54b92280bc9b66699d
```


### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux - I also copied the 1p7 files into /proj/sot/ska/data/agasc/rc so it would run all the healpix tests.
```
ska3-jeanconn-fido> echo $AGASC_DIR
/proj/sot/ska/data/agasc/rc
ska3-jeanconn-fido> git rev-parse HEAD
99493884f148f779fe196b54b92280bc9b66699d
ska3-jeanconn-fido> pytest
============================================================== test session starts ===============================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 75 items                                                                                                                               

agasc/tests/test_agasc_1.py .....                                                                                                          [  6%]
agasc/tests/test_agasc_2.py .............................................                                                                  [ 66%]
agasc/tests/test_agasc_healpix.py ...........                                                                                              [ 81%]
agasc/tests/test_obs_status.py ..............                                                                                              [100%]

========================================================= 75 passed in 97.38s (0:01:37)
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
