### PR TITLE
use default agasc file when updating magnitudes in supplement

### DIFF
--- a/agasc/supplement/magnitudes/star_obs_catalogs.py
+++ b/agasc/supplement/magnitudes/star_obs_catalogs.py
@@ -2,6 +2,7 @@ import os
 
 import numpy as np
 import tables
+import agasc
 from astropy import table
 from astropy.table import Table, join
 from chandra_aca.transform import yagzag_to_pixels
@@ -35,7 +36,7 @@ def get_star_observations(start=None, stop=None, obsid=None):
     )
 
     # Add mag_aca_err column
-    filename = os.path.join(os.environ["SKA"], "data", "agasc", "proseco_agasc_1p7.h5")
+    filename = agasc.get_agasc_filename()
     with tables.open_file(filename) as h5:
         agasc_ids = h5.root.data.col("AGASC_ID")
         mag_errs = h5.root.data.col("MAG_ACA_ERR") * 0.01


### PR DESCRIPTION
The current master uses agasc 1p7 when updating supplement magnitudes. This PR fixes that.

## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

Changes in this PR are also in PR #181.