### PR TITLE
Do not update supplement magnitudes if d_mag is small

### DIFF
--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -11,7 +11,6 @@ import numba
 import numpy as np
 import scipy.special
 import scipy.stats
-import Ska.quatutil
 from astropy.table import Table, vstack
 from Chandra.Time import DateTime
 from chandra_aca.transform import count_rate_to_mag, pixels_to_yagzag
@@ -22,6 +21,7 @@ from mica.archive import aca_l0
 from mica.archive.aca_dark.dark_cal import get_dark_cal_image
 from Quaternion import Quat
 
+import Ska.quatutil
 from agasc import get_star
 
 from . import star_obs_catalogs

--- a/agasc/supplement/magnitudes/star_obs_catalogs.py
+++ b/agasc/supplement/magnitudes/star_obs_catalogs.py
@@ -1,12 +1,11 @@
-import os
-
 import numpy as np
 import tables
-import agasc
 from astropy import table
 from astropy.table import Table, join
 from chandra_aca.transform import yagzag_to_pixels
 from kadi import commands, events
+
+import agasc
 
 STARS_OBS = None
 """The table of star observations"""

--- a/agasc/supplement/magnitudes/star_obs_catalogs.py
+++ b/agasc/supplement/magnitudes/star_obs_catalogs.py
@@ -2,6 +2,7 @@ import os
 
 import numpy as np
 import tables
+import agasc
 from astropy import table
 from astropy.table import Table, join
 from chandra_aca.transform import yagzag_to_pixels
@@ -35,7 +36,7 @@ def get_star_observations(start=None, stop=None, obsid=None):
     )
 
     # Add mag_aca_err column
-    filename = os.path.join(os.environ["SKA"], "data", "agasc", "proseco_agasc_1p7.h5")
+    filename = agasc.get_agasc_filename()
     with tables.open_file(filename) as h5:
         agasc_ids = h5.root.data.col("AGASC_ID")
         mag_errs = h5.root.data.col("MAG_ACA_ERR") * 0.01

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -318,7 +318,8 @@ def update_supplement(agasc_stats, filename, include_all=True, d_mag_threshold=0
                 # from those, find the ones which differ in last observation time
                 # (any others will not be updated)
                 last_obs_differs = (
-                    outliers_current[i_cur]["last_obs_time"] != outliers_new[i_new]["last_obs_time"]
+                    outliers_current[i_cur]["last_obs_time"]
+                    != outliers_new[i_new]["last_obs_time"]
                 )
                 i_cur = i_cur[last_obs_differs]
                 i_new = i_new[last_obs_differs]
@@ -330,11 +331,15 @@ def update_supplement(agasc_stats, filename, include_all=True, d_mag_threshold=0
 
                 # reset new values in the cases we do not want to update mag_aca
                 updt_mag = (
-                    (np.abs(current["mag_aca"] - new["mag_aca"]) > d_mag_threshold)
-                    | (np.abs(current["mag_aca_err"] - new["mag_aca_err"]) > d_mag_threshold)
+                    np.abs(current["mag_aca"] - new["mag_aca"]) > d_mag_threshold
+                ) | (
+                    np.abs(current["mag_aca_err"] - new["mag_aca_err"])
+                    > d_mag_threshold
                 )
                 new["mag_aca"] = np.where(updt_mag, new["mag_aca"], current["mag_aca"])
-                new["mag_aca_err"] = np.where(updt_mag, current["mag_aca_err"], new["mag_aca_err"])
+                new["mag_aca_err"] = np.where(
+                    updt_mag, current["mag_aca_err"], new["mag_aca_err"]
+                )
 
                 # overwrite current values with new values
                 outliers_current[i_cur] = new
@@ -342,7 +347,9 @@ def update_supplement(agasc_stats, filename, include_all=True, d_mag_threshold=0
                 # and calculate diff to return)
                 updated_stars = np.zeros(len(new), dtype=MAGS_DTYPE)
                 updated_stars["mag_aca"] = new["mag_aca"] - current["mag_aca"]
-                updated_stars["mag_aca_err"] = new["mag_aca_err"] - current["mag_aca_err"]
+                updated_stars["mag_aca_err"] = (
+                    new["mag_aca_err"] - current["mag_aca_err"]
+                )
                 updated_stars["agasc_id"] = new["agasc_id"]
                 updated_stars = updated_stars[updt_mag]  # all others are zero
 

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -338,7 +338,7 @@ def update_supplement(agasc_stats, filename, include_all=True, d_mag_threshold=0
                 )
                 new["mag_aca"] = np.where(updt_mag, new["mag_aca"], current["mag_aca"])
                 new["mag_aca_err"] = np.where(
-                    updt_mag, current["mag_aca_err"], new["mag_aca_err"]
+                    updt_mag, new["mag_aca_err"], current["mag_aca_err"]
                 )
 
                 # overwrite current values with new values

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -351,7 +351,6 @@ def update_supplement(agasc_stats, filename, include_all=True, d_mag_threshold=0
                     new["mag_aca_err"] - current["mag_aca_err"]
                 )
                 updated_stars["agasc_id"] = new["agasc_id"]
-                updated_stars = updated_stars[updt_mag]  # all others are zero
 
                 # find agasc_ids in new list but not in current list
                 new_stars = ~np.in1d(
@@ -740,16 +739,32 @@ def do(
             multi_star_html_args["no_progress"] = no_progress
 
         else:
+            updt_mag = (updated_stars["mag_aca"] != 0) | (
+                updated_stars["mag_aca_err"] != 0
+            )
             sections = [
                 {"id": "new_stars", "title": "New Stars", "stars": new_stars},
                 {
                     "id": "updated_stars",
                     "title": "Updated Stars",
-                    "stars": updated_stars["agasc_id"] if len(updated_stars) else [],
+                    "stars": (
+                        updated_stars["agasc_id"][updt_mag].tolist()
+                        if len(updated_stars[updt_mag])
+                        else []
+                    ),
+                },
+                {
+                    "id": "not_updated_stars",
+                    "title": "Magnitude not Updated",
+                    "stars": (
+                        updated_stars["agasc_id"][~updt_mag].tolist()
+                        if len(updated_stars[~updt_mag])
+                        else []
+                    ),
                 },
                 {
                     "id": "other_stars",
-                    "title": "Magnitude not Updated",
+                    "title": "Other (unexpectedly not updated)",
                     "stars": list(
                         agasc_stats["agasc_id"][
                             ~np.in1d(agasc_stats["agasc_id"], new_stars)

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -265,7 +265,7 @@ def update_mag_stats(obs_stats, agasc_stats, fails, outdir="."):
             pickle.dump(fails, out)
 
 
-def update_supplement(agasc_stats, filename, include_all=True):
+def update_supplement(agasc_stats, filename, include_all=True, d_mag_threshold=0.01):
     """
     Update the magnitude table of the AGASC supplement.
 
@@ -274,6 +274,9 @@ def update_supplement(agasc_stats, filename, include_all=True):
     :param include_all: bool
         if True, all OK entries are included in supplement.
         if False, only OK entries marked 'selected_*'
+    :param d_mag_threshold: float
+        If the absolute difference between the new and the current mag_aca is less than this value,
+        mag_aca is not updated. Note that last_obs_time is always updated.
     :return:
     """
     if agasc_stats is None or len(agasc_stats) == 0:
@@ -312,33 +315,46 @@ def update_supplement(agasc_stats, filename, include_all=True):
                     outliers_current["agasc_id"],
                     return_indices=True,
                 )
+                # from those, find the ones which differ in last observation time
+                # (any others will not be updated)
+                last_obs_differs = (
+                    outliers_current[i_cur]["last_obs_time"] != outliers_new[i_new]["last_obs_time"]
+                )
+                i_cur = i_cur[last_obs_differs]
+                i_new = i_new[last_obs_differs]
+
+                # The original will not modified when changing these tables.
                 current = outliers_current[i_cur]
                 new = outliers_new[i_new]
+                assert len(new) == len(current)  # this should always be true
 
-                # from those, find the ones which differ in last observation time
-                i_cur = i_cur[current["last_obs_time"] != new["last_obs_time"]]
-                i_new = i_new[current["last_obs_time"] != new["last_obs_time"]]
-                # overwrite current values with new values (and calculate diff to return)
-                updated_stars = np.zeros(len(outliers_new[i_new]), dtype=MAGS_DTYPE)
-                updated_stars["mag_aca"] = (
-                    outliers_new[i_new]["mag_aca"] - outliers_current[i_cur]["mag_aca"]
+                # reset new values in the cases we do not want to update mag_aca
+                updt_mag = (
+                    (np.abs(current["mag_aca"] - new["mag_aca"]) > d_mag_threshold)
+                    | (np.abs(current["mag_aca_err"] - new["mag_aca_err"]) > d_mag_threshold)
                 )
-                updated_stars["mag_aca_err"] = (
-                    outliers_new[i_new]["mag_aca_err"]
-                    - outliers_current[i_cur]["mag_aca_err"]
-                )
-                updated_stars["agasc_id"] = outliers_new[i_new]["agasc_id"]
-                outliers_current[i_cur] = outliers_new[i_new]
+                new["mag_aca"] = np.where(updt_mag, new["mag_aca"], current["mag_aca"])
+                new["mag_aca_err"] = np.where(updt_mag, current["mag_aca_err"], new["mag_aca_err"])
+
+                # overwrite current values with new values
+                outliers_current[i_cur] = new
+
+                # and calculate diff to return)
+                updated_stars = np.zeros(len(new), dtype=MAGS_DTYPE)
+                updated_stars["mag_aca"] = new["mag_aca"] - current["mag_aca"]
+                updated_stars["mag_aca_err"] = new["mag_aca_err"] - current["mag_aca_err"]
+                updated_stars["agasc_id"] = new["agasc_id"]
+                updated_stars = updated_stars[updt_mag]  # all others are zero
 
                 # find agasc_ids in new list but not in current list
                 new_stars = ~np.in1d(
                     outliers_new["agasc_id"], outliers_current["agasc_id"]
                 )
+
                 # and add them to the current list
-                outliers_current = np.concatenate(
-                    [outliers_current, outliers_new[new_stars]]
+                outliers = np.sort(
+                    np.concatenate([outliers_current, outliers_new[new_stars]])
                 )
-                outliers = np.sort(outliers_current)
 
                 new_stars = outliers_new[new_stars]["agasc_id"]
 
@@ -726,7 +742,7 @@ def do(
                 },
                 {
                     "id": "other_stars",
-                    "title": "Other Stars",
+                    "title": "Magnitude not Updated",
                     "stars": list(
                         agasc_stats["agasc_id"][
                             ~np.in1d(agasc_stats["agasc_id"], new_stars)

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -344,7 +344,7 @@ def update_supplement(agasc_stats, filename, include_all=True, d_mag_threshold=0
                 # overwrite current values with new values
                 outliers_current[i_cur] = new
 
-                # and calculate diff to return)
+                # and calculate diff to return
                 updated_stars = np.zeros(len(new), dtype=MAGS_DTYPE)
                 updated_stars["mag_aca"] = new["mag_aca"] - current["mag_aca"]
                 updated_stars["mag_aca_err"] = (

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,9 +2,9 @@
 target-version = "py310"
 
 # fix = true
-unfixable = []
+lint.unfixable = []
 
-select = [
+lint.select = [
   "I", # isort
   "F", # pyflakes
   "E", "W", # pycodestyle
@@ -23,7 +23,7 @@ select = [
   "PGH" # pygrep-hooks
 ]
 
-ignore = [
+lint.ignore = [
   "ISC001", # Disable this for compatibility with ruff format
   "B028", # No explicit `stacklevel` keyword argument found
   "B905", # `zip()` without an explicit `strict=` parameter
@@ -39,7 +39,7 @@ ignore = [
 ]
 
 # TODO : fix these and stop ignoring. Commented out ones are common and OK to except.
-extend-ignore = [
+lint.extend-ignore = [
   "PGH004", # Use specific rule codes when using `noqa`
 ]
 
@@ -48,7 +48,7 @@ extend-exclude = [
   "validate",
 ]
 
-[pycodestyle]
+[lint.pycodestyle]
 max-line-length = 100 # E501 reports lines that exceed the length of 100.
 
 [lint.extend-per-file-ignores]


### PR DESCRIPTION
## Description

When updating supplement, do not update magnitudes that change by less than 0.01. A majority of updates are less than 0.01, so this PR can make the reports shorter.

Currently, if a star's magnitude is not updated, it appears in the last section of the report, titled "Magnitude not Updated" ("Other Stars" in the master version). This section could be removed.

Also updated the names of ruff options in `ruff.toml`.

## Interface impacts
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
- [x] Mac
- [x] Linux (HEAD)

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

Note that this PR is based on the branch for #180, so this test also checks that things work there.
agasc_supplement_diff.html

I ran the weekly processing for one day, in both this PR's branch and master. The resulting reports and diffs are here:
- branch ([2f58e86](https://github.com/sot/agasc/tree/2f58e86a57c8ea4f31c458c8894f1b2a500a336f)):
  - [supplement reports](https://cxc.cfa.harvard.edu/mta/ASPECT/jgonzalez/agasc/pr-181/branch/supplement_reports/2024:176/)
  - [supplement diff](https://cxc.cfa.harvard.edu/mta/ASPECT/jgonzalez/agasc/pr-181/branch/agasc_supplement_diff.html)
- master:
  - [supplement reports](https://cxc.cfa.harvard.edu/mta/ASPECT/jgonzalez/agasc/pr-181/master/supplement_reports/2024:176/)
  - [supplement diff](https://cxc.cfa.harvard.edu/mta/ASPECT/jgonzalez/agasc/pr-181/master/agasc_supplement_diff.html)

These are the steps to run these tests (same config as weekly processing, but shorter time range):
- ```
   for f in agasc1p7.h5 agasc_healpix_1p7.h5 miniagasc_1p7.h5 miniagasc.h5 proseco_agasc_1p7.h5;
   do ln -s /proj/sot/ska/data/agasc/rc/$f .;
   done;
   cp /proj/sot/.snapshot/weekly.2024-06-16_0015/ska/data/agasc/rc/agasc_supplement.h5 .
   cp /proj/sot/.snapshot/weekly.2024-06-16_0015/ska/data/agasc/rc/mag_stats_* .
   cp /proj/sot/.snapshot/weekly.2024-06-16_0015/ska/data/agasc/rc/mag_stats_* .
   cp /proj/sot/ska/data/agasc/rc/supplement_reports/weekly/latest/call_args.yml
   ```
- Edit `call_args.yml` to change `output_dir`, `reports_dir`, `start` and `stop`:
   ```
   output_dir: /proj/sot/ska/jgonzalez/agasc/smaller-update/branch
   reports_dir: /proj/sot/ska/jgonzalez/agasc/smaller-update/branch/supplement_reports
   start: 2024:169:00:00:00.000
   stop: 2024:170:00:00:00.000
   ```
- ```
   agasc-update-magnitudes --args-file call_args.yml
   agasc-supplement-diff \
     --from /proj/sot/.snapshot/weekly.2024-06-16_0015/ska/data/agasc/rc/agasc_supplement.h5 \
     --to agasc_supplement.h5
     -o agasc_supplement_diff.html
   ```