### PR TITLE
Support `columns` key in `get_agasc_cone` and improve caching

### DIFF
--- a/.github/workflows/python-formatting.yml
+++ b/.github/workflows/python-formatting.yml
@@ -1,4 +1,4 @@
-name: lint code using ruff
+name: check format using ruff
 on: [push]
 jobs:
   ruff:
@@ -6,3 +6,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: chartboost/ruff-action@v1
+        with:
+          args: format --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.1.5
+  rev: v0.5.1
   hooks:
     # Run the linter.
     - id: ruff

--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -539,12 +539,13 @@ def get_agasc_cone(
     rad_pm = radius + (0.1 if pm_filter else 0.0)
 
     # Ensure that the columns we need are read from the AGASC file, excluding PMCORR
-    # columns if supplied since they are not in the HDF5. Sort the columns so caching is
-    # effective.
+    # columns if supplied since they are not in the HDF5.
     columns_query = (
         None
         if columns is None
-        else tuple(sorted(set(columns) - {"RA_PMCORR", "DEC_PMCORR"}))
+        else tuple(
+            column for column in columns if column not in ("RA_PMCORR", "DEC_PMCORR")
+        )
     )
 
     # Minimal columns to compute PM-corrected positions and do filtering.

--- a/agasc/healpix.py
+++ b/agasc/healpix.py
@@ -81,6 +81,7 @@ def get_stars_from_healpix_h5(
     dec: float,
     radius: float,
     agasc_file: str | Path,
+    columns: list[str] | tuple[str] | None = None,
     cache: bool = False,
 ) -> Table:
     """
@@ -97,6 +98,8 @@ def get_stars_from_healpix_h5(
         Radius of the search cone, in degrees.
     agasc_file : str or Path
         Path to the HDF5 file containing the AGASC data with a HEALPix index.
+    columns : list or tuple, optional
+        The columns to read from the AGASC file. If not specified, all columns are read.
     cache : bool, optional
         Whether to cache the AGASC data in memory. Default is False.
 
@@ -121,7 +124,7 @@ def get_stars_from_healpix_h5(
     def make_stars_list(h5_file):
         for healpix_index in healpix_indices:
             idx0, idx1 = healpix_index_map[healpix_index]
-            stars = read_h5_table(h5_file, row0=idx0, row1=idx1, cache=cache)
+            stars = read_h5_table(h5_file, columns, row0=idx0, row1=idx1, cache=cache)
             stars_list.append(stars)
 
     if cache:

--- a/agasc/healpix.py
+++ b/agasc/healpix.py
@@ -124,7 +124,9 @@ def get_stars_from_healpix_h5(
     def make_stars_list(h5_file):
         for healpix_index in healpix_indices:
             idx0, idx1 = healpix_index_map[healpix_index]
-            stars = read_h5_table(h5_file, columns, row0=idx0, row1=idx1, cache=cache)
+            stars = read_h5_table(
+                h5_file, row0=idx0, row1=idx1, cache=cache, columns=columns
+            )
             stars_list.append(stars)
 
     if cache:

--- a/agasc/scripts/mag_estimate_report.py
+++ b/agasc/scripts/mag_estimate_report.py
@@ -76,7 +76,6 @@ def get_parser():
 
 
 def main():
-
     args = get_parser().parse_args()
 
     args.output_dir = Path(os.path.expandvars(args.output_dir))

--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -5,6 +5,7 @@ Update Magnitude Statistics.
 
 
 """
+
 import argparse
 import logging
 import os
@@ -245,7 +246,6 @@ def get_next_file_name(file_name):
 
 
 def main():
-
     args = get_args()
     args_log_file = args.pop("args_log_file")
 

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -11,6 +11,7 @@ import numba
 import numpy as np
 import scipy.special
 import scipy.stats
+import Ska.quatutil
 from astropy.table import Table, vstack
 from Chandra.Time import DateTime
 from chandra_aca.transform import count_rate_to_mag, pixels_to_yagzag
@@ -21,7 +22,6 @@ from mica.archive import aca_l0
 from mica.archive.aca_dark.dark_cal import get_dark_cal_image
 from Quaternion import Quat
 
-import Ska.quatutil
 from agasc import get_star
 
 from . import star_obs_catalogs

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -289,9 +289,9 @@ class MagEstimateReport:
                 agasc_stats["t_mean_dr3"] - agasc_stats["mag_aca"]
             ) / agasc_stats["mag_aca_err"]
             agasc_stats["new"] = True
-            agasc_stats["new"][
-                np.in1d(agasc_stats["agasc_id"], updated_star_ids)
-            ] = False
+            agasc_stats["new"][np.in1d(agasc_stats["agasc_id"], updated_star_ids)] = (
+                False
+            )
             agasc_stats["update_mag_aca"] = np.nan
             agasc_stats["update_mag_aca_err"] = np.nan
             agasc_stats["last_obs"] = CxoTime(agasc_stats["last_obs_time"]).date
@@ -457,7 +457,7 @@ class MagEstimateReport:
         timeline["std"] = np.nan
         timeline["mag_mean"] = np.nan
         timeline["mag_std"] = np.nan
-        for obsid in np.unique(timeline["obsid"]):
+        for obsid in np.unique(timeline["obsid"]):  # noqa: PLR1704
             sel = obs_stats["obsid"] == obsid
             if draw_obs_mag_stats and np.any(sel):
                 timeline["mag_mean"][timeline["obsid"] == obsid] = obs_stats[sel][
@@ -825,7 +825,7 @@ class MagEstimateReport:
                 all_ok = timeline["obs_ok"] & all_ok
                 flags = [("OBS not OK", ~timeline["obs_ok"])] + flags
 
-            for obsid in obsids:
+            for obsid in obsids:  # noqa: PLR1704
                 limits[obsid] = (
                     timeline["x"][timeline["obsid"] == obsid].min(),
                     timeline["x"][timeline["obsid"] == obsid].max(),

--- a/agasc/supplement/magnitudes/star_obs_catalogs.py
+++ b/agasc/supplement/magnitudes/star_obs_catalogs.py
@@ -1,6 +1,5 @@
 import numpy as np
 import tables
-import agasc
 from astropy import table
 from astropy.table import Table, join
 from chandra_aca.transform import yagzag_to_pixels

--- a/agasc/tests/test_agasc_healpix.py
+++ b/agasc/tests/test_agasc_healpix.py
@@ -3,6 +3,7 @@
 
 This uses AGASC 1.8 which is the first release to use such ordering.
 """
+
 import numpy as np
 import pytest
 

--- a/create_near_neighbor_ids.py
+++ b/create_near_neighbor_ids.py
@@ -11,6 +11,7 @@ of AGASC 1.7 on a local (fast) drive.
 This creates an output file like ``agasc<version>_near_neighbor_ids.fits.gz`` which can
 be used by ``create_derived_agasc_h5.py`` to include near neighbors.
 """
+
 import argparse
 from pathlib import Path
 

--- a/dev/profile_cache.py
+++ b/dev/profile_cache.py
@@ -1,31 +1,56 @@
 """Profile performance of get_agasc_cone with and without cache"""
 
+import itertools
 import time
 from pathlib import Path
 
 import numpy as np
 
-from agasc import get_agasc_cone, get_agasc_filename
+from agasc import __version__, get_agasc_cone, get_agasc_filename
+
+print(f"agasc version: {__version__}")
 
 agasc_healpix = get_agasc_filename("proseco_agasc_*", version="1p8", allow_rc=True)
 agasc_dec = get_agasc_filename("proseco_agasc_*", version="1p7")
 
-ras = np.random.uniform(0, 360, 100)
-decs = np.random.uniform(-90, 90, 100)
+n_iter = 300
+np.random.seed(0)
+ras = np.random.uniform(0, 360, n_iter)
+decs = np.random.uniform(-90, 90, n_iter)
+
+colnames = (
+    "AGASC_ID",
+    "RA",
+    "DEC",
+    "PM_RA",
+    "PM_DEC",
+    "EPOCH",
+    "MAG_ACA",
+)
 
 
 def print_timing(filename, cache):
-    t0 = time.time()
-    for ra, dec in zip(ras, decs):
-        get_agasc_cone(
-            ra,
-            dec,
-            radius=1.5,
-            agasc_file=filename,
-            date="2019:001",
-            cache=cache,
+    t0 = 0
+    for cols in (None, colnames):
+        for idx, ra, dec in zip(itertools.count(), ras, decs):
+            get_agasc_cone(
+                ra,
+                dec,
+                radius=1.5,
+                agasc_file=filename,
+                date="2019:001",
+                cache=cache,
+                columns=cols,
+                fix_color1=False,
+                use_supplement=False,
+                pm_filter=False,
+            )
+            if idx == 0:
+                t0 = time.time()
+        dt_ms = (time.time() - t0) / (len(ras) - 1) * 1000
+        print(
+            f"filename={Path(filename).name} {cache=} columns:{cols is not None} {dt_ms:.2f} ms"
         )
-    print(f"filename={Path(filename).name} {cache=} {time.time() - t0:.2f}")
 
 
 print_timing(agasc_dec, cache=False)

--- a/dev/profile_cache.py
+++ b/dev/profile_cache.py
@@ -5,10 +5,9 @@ import time
 from pathlib import Path
 
 import numpy as np
+from astropy.table import Table
 
 from agasc import __version__, get_agasc_cone, get_agasc_filename
-
-print(f"agasc version: {__version__}")
 
 agasc_healpix = get_agasc_filename("proseco_agasc_*", version="1p8", allow_rc=True)
 agasc_dec = get_agasc_filename("proseco_agasc_*", version="1p7")
@@ -29,31 +28,39 @@ colnames = (
 )
 
 
-def print_timing(filename, cache):
+def get_timing(filename, cache, cols):
     t0 = 0
-    for cols in (None, colnames):
-        for idx, ra, dec in zip(itertools.count(), ras, decs):
-            get_agasc_cone(
-                ra,
-                dec,
-                radius=1.5,
-                agasc_file=filename,
-                date="2019:001",
-                cache=cache,
-                columns=cols,
-                fix_color1=False,
-                use_supplement=False,
-                pm_filter=False,
-            )
-            if idx == 0:
-                t0 = time.time()
-        dt_ms = (time.time() - t0) / (len(ras) - 1) * 1000
-        print(
-            f"filename={Path(filename).name} {cache=} columns:{cols is not None} {dt_ms:.2f} ms"
+    for idx, ra, dec in zip(itertools.count(), ras, decs):
+        get_agasc_cone(
+            ra,
+            dec,
+            radius=1.5,
+            agasc_file=filename,
+            date="2019:001",
+            cache=cache,
+            columns=cols,
+            fix_color1=False,
+            use_supplement=False,
+            pm_filter=False,
         )
+        if idx == 0:
+            t0 = time.time()
+    dt_ms = (time.time() - t0) / (len(ras) - 1) * 1000
+    row = (Path(filename).name, cache, cols is None, dt_ms)
+    return row
 
 
-print_timing(agasc_dec, cache=False)
-print_timing(agasc_dec, cache=True)
-print_timing(agasc_healpix, cache=False)
-print_timing(agasc_healpix, cache=True)
+rows = []
+for filename in (agasc_dec, agasc_healpix):
+    for cache in (False, True):
+        for cols in (None, colnames):
+            print(".", end="", flush=True)
+            rows.append(get_timing(filename, cache, cols))
+
+out = Table(rows=rows, names=("filename", "cache", "all_columns", "dt"))
+out["dt"].format = ".2f"
+out["dt"].unit = "ms"
+
+print()
+print(f"agasc version: {__version__}")
+out.pprint_all()

--- a/ruff.toml
+++ b/ruff.toml
@@ -46,6 +46,7 @@ lint.extend-ignore = [
 extend-exclude = [
   "docs",
   "validate",
+  "*.ipynb",
 ]
 
 [lint.pycodestyle]


### PR DESCRIPTION
## Description

This is driven by the need to support AGASC 1.8 in `kadi.observations.get_starcats()`. The `kadi.observations` module defines a `get_agasc_cone_fast` that caches a limited set of `proseco_agasc` columns, but it won't work with AGASC 1.8.

This PR implements support for `columns` in `get_agasc_cone` with caching which works with 1.7 and 1.8. The plan is then to remove `kadi.observations.get_agasc_cone_fast` (or make it a thin wrapper around cached `get_agasc_cone`).

### Other changes

- Do not limit the cache size to 1 (last). It is up to the user to manage memory if multiple AGASCs or column combinations are cached.
- Do not require `COLOR1` column. If not present then `update_color1_column()` returns immediately. Previously it would crash.
- Update `dev/profile_cache.py` to include a case with `columns` defined.
- Update for ruff 0.5.1, remove black in python-linting, and make a few non-impacting format / lint-based changes.

## Related PR's
- https://github.com/sot/kadi/pull/332

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
New keywords `columns` in `get_agasc_cone`.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  agasc git:(cone-by-columns-with-caching) git rev-parse HEAD                                                              
154e6e51820977ad1820533723d135009784bafd
(ska3) ➜  agasc git:(cone-by-columns-with-caching) pytest
======================================================== test session starts ========================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 77 items                                                                                                                  

agasc/tests/test_agasc_1.py .......                                                                                           [  9%]
agasc/tests/test_agasc_2.py ..........sssss..........ss..................                                                     [ 67%]
agasc/tests/test_agasc_healpix.py ...........                                                                                 [ 81%]
agasc/tests/test_obs_status.py ..............                                                                                 [100%]

=================================================== 70 passed, 7 skipped in 8.20s ===================================================
```

Independent check of unit tests by Jean
- [x] Linux

```
jeanconn-fido> pytest
=================================================== test session starts ====================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 77 items                                                                                                         

agasc/tests/test_agasc_1.py .......                                                                                  [  9%]
agasc/tests/test_agasc_2.py .............................................                                            [ 67%]
agasc/tests/test_agasc_healpix.py ...........                                                                        [ 81%]
agasc/tests/test_obs_status.py ..............                                                                        [100%]

============================================== 77 passed in 222.93s (0:03:42) ==============================================
jeanconn-fido> git rev-parse HEAD
154e6e51820977ad1820533723d135009784bafd
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
```
(ska3) ➜  agasc git:(cone-by-columns-with-caching) env PYTHONPATH=$PWD python dev/profile_cache.py
........
agasc version: 4.20.1.dev10+g154e6e5
        filename         cache all_columns  dt 
                                            ms 
------------------------ ----- ----------- ----
    proseco_agasc_1p7.h5 False        True 6.74
    proseco_agasc_1p7.h5 False       False 9.20
    proseco_agasc_1p7.h5  True        True 2.23
    proseco_agasc_1p7.h5  True       False 2.02
proseco_agasc_1p8rc11.h5 False        True 4.52
proseco_agasc_1p8rc11.h5 False       False 4.39
proseco_agasc_1p8rc11.h5  True        True 1.20
proseco_agasc_1p8rc11.h5  True       False 0.75
```
