### PR TITLE
Get last_updated supplement table without error

### DIFF
--- a/agasc/supplement/utils.py
+++ b/agasc/supplement/utils.py
@@ -127,7 +127,11 @@ def get_supplement_table(
             dat = np.array([], dtype=dtypes.get(name, []))
 
     if name in ["agasc_versions", "last_updated"]:
-        out = {name: dat[0][name] for name in dat.dtype.names} if len(dat) else {}
+        out = (
+            {name: dat[0][name].decode() for name in dat.dtype.names}
+            if len(dat)
+            else {}
+        )
     elif as_dict:
         out = {}
         keys_names = {

--- a/agasc/supplement/utils.py
+++ b/agasc/supplement/utils.py
@@ -126,26 +126,25 @@ def get_supplement_table(
             )
             dat = np.array([], dtype=dtypes.get(name, []))
 
-    if as_dict:
-        if name in ["agasc_versions", "last_updated"]:
-            out = {name: dat[0][name] for name in dat.dtype.names} if len(dat) else {}
-        else:
-            out = {}
-            keys_names = {
-                "mags": ["agasc_id"],
-                "bad": ["agasc_id"],
-                "obs": ["agasc_id", "mp_starcat_time"],
+    if name in ["agasc_versions", "last_updated"]:
+        out = {name: dat[0][name] for name in dat.dtype.names} if len(dat) else {}
+    elif as_dict:
+        out = {}
+        keys_names = {
+            "mags": ["agasc_id"],
+            "bad": ["agasc_id"],
+            "obs": ["agasc_id", "mp_starcat_time"],
+        }
+        key_names = keys_names[name]
+        for row in dat:
+            # Make the key, coercing the values from numpy to native Python
+            key = tuple(row[nm].item() for nm in key_names)
+            if len(key) == 1:
+                key = key[0]
+            # Make the value from the remaining non-key column names
+            out[key] = {
+                nm: row[nm].item() for nm in row.dtype.names if nm not in key_names
             }
-            key_names = keys_names[name]
-            for row in dat:
-                # Make the key, coercing the values from numpy to native Python
-                key = tuple(row[nm].item() for nm in key_names)
-                if len(key) == 1:
-                    key = key[0]
-                # Make the value from the remaining non-key column names
-                out[key] = {
-                    nm: row[nm].item() for nm in row.dtype.names if nm not in key_names
-                }
     else:
         out = Table(dat)
         index = {agasc_id: idx for idx, agasc_id in enumerate(out["agasc_id"])}

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -26,12 +26,13 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import Ska.Shell
 import tables
 from astropy.io import ascii
 from astropy.table import Row, Table
+from cxotime import CxoTime
 
 import agasc
+import Ska.Shell
 from agasc import write_agasc
 
 os.environ[agasc.SUPPLEMENT_ENABLED_ENV] = "False"
@@ -641,3 +642,10 @@ def test_write_missing_column(tmp_path, stars_in):
 
     # OK for full_agasc=False
     write_agasc(temp, stars=stars, version="test", full_agasc=False)
+
+
+def test_last_updated():
+    last_updated = agasc.get_supplement_table("last_updated")
+    assert CxoTime(last_updated["supplement"]).date.startswith("20")
+
+    _ = agasc.get_supplement_table("agasc_versions")


### PR DESCRIPTION
## Description

This PR fixes an exception that happens when one does `agasc.get_supplement_table("last_updated")` without specifying `as_dict=True`. Specifying `as_dict=True` is not intuitive and not expected, and anyway 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests

Added a unit test for this and checked that it fails on master as expected.

- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
