### PR TITLE
Handle bad stars from supplement in one test

### DIFF
--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -427,9 +427,13 @@ def test_supplement_get_agasc_cone():
     )
     ok = stars2["MAG_CATID"] == agasc.MAG_CATID_SUPPLEMENT
 
-    change_names = ["MAG_CATID", "COLOR1", "MAG_ACA", "MAG_ACA_ERR"]
+    change_names = ["MAG_CATID", "COLOR1", "MAG_ACA", "MAG_ACA_ERR", "CLASS"]
     for name in set(stars1.colnames) - set(change_names):
         assert np.all(stars1[name] == stars2[name])
+
+    # For CLASS the only ones that are different should have the "bad" class 100
+    class_nok = stars2["CLASS"] != stars1["CLASS"]
+    assert np.all(stars2["CLASS"][class_nok] == 100)
 
     assert not np.any(stars1["MAG_CATID"] == agasc.MAG_CATID_SUPPLEMENT)
 


### PR DESCRIPTION
## Description

Handle bad stars (CLASS=100) from supplement in one test.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Without this fix you get this when the bad-color-stars-added supplement is promoted.
```
(ska3-flight-latest) flame:agasc jean$ pytest
=================================================================================== test session starts ====================================================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 77 items                                                                                                                                                                         

agasc/tests/test_agasc_1.py .......                                                                                                                                                  [  9%]
agasc/tests/test_agasc_2.py ..........sssss..........ss.F................                                                                                                            [ 67%]
agasc/tests/test_agasc_healpix.py .ssssssssss                                                                                                                                        [ 81%]
agasc/tests/test_obs_status.py ..............                                                                                                                                        [100%]

========================================================================================= FAILURES =========================================================================================
______________________________________________________________________________ test_supplement_get_agasc_cone ______________________________________________________________________________

    @pytest.mark.skipif(NO_MAGS_IN_SUPPLEMENT, reason="no mags in supplement")
    def test_supplement_get_agasc_cone():
        ra, dec = 282.53, -0.38  # Obsid 22429 with a couple of color1=1.5 stars
        stars1 = agasc.get_agasc_cone(
            ra, dec, date="2021:001", agasc_file=MINIAGASC_1P7, use_supplement=False
        )
        stars2 = agasc.get_agasc_cone(
            ra, dec, date="2021:001", agasc_file=MINIAGASC_1P7, use_supplement=True
        )
        ok = stars2["MAG_CATID"] == agasc.MAG_CATID_SUPPLEMENT
    
        change_names = ["MAG_CATID", "COLOR1", "MAG_ACA", "MAG_ACA_ERR"]
        for name in set(stars1.colnames) - set(change_names):
>           assert np.all(stars1[name] == stars2[name])
E           assert False
E            +  where False = <function all at 0x101fb9570>(<Column name=... 0\n  0\n  0\n  0 == <Column name=... 0\n  0\n  0\n  0
E            +    where <function all at 0x101fb9570> = np.all
E               Use -v to get more diff)

agasc/tests/test_agasc_2.py:432: AssertionError
================================================================================= short test summary info ==================================================================================
FAILED agasc/tests/test_agasc_2.py::test_supplement_get_agasc_cone - assert False
========================================================================= 1 failed, 59 passed, 17 skipped in 7.28s
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
I had just copied the candidate supplement with no-color-bad-stars-added over the agasc_supplement in my ska data.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac arm64

```
jeanconn-fido> md5sum /proj/sot/ska/data/agasc/rc/promote/agasc_supplement.h5 
144e5faf28d2f93812bfe74210d1c3c7  /proj/sot/ska/data/agasc/rc/promote/agasc_supplement.h5
jeanconn-fido> Use "logout" to leave the shell.
jeanconn-fido> logout
Connection to localhost closed.
(ska3-flight-latest) flame:agasc jean$ md5 /Users/jean/ska/data/agasc/agasc_supplement.h5 
MD5 (/Users/jean/ska/data/agasc/agasc_supplement.h5) = 144e5faf28d2f93812bfe74210d1c3c7
(ska3-flight-latest) flame:agasc jean$ git rev-parse HEAD
4df95afbbbdd220700dee683acd716128f8e03af
(ska3-flight-latest) flame:agasc jean$ pytest
=================================================================================== test session starts ====================================================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 77 items                                                                                                                                                                         

agasc/tests/test_agasc_1.py .......                                                                                                                                                  [  9%]
agasc/tests/test_agasc_2.py ..........sssss..........ss..................                                                                                                            [ 67%]
agasc/tests/test_agasc_healpix.py .ssssssssss                                                                                                                                        [ 81%]
agasc/tests/test_obs_status.py ..............                                                                                                                                        [100%]

============================================================================== 60 passed, 17 skipped in 8.14s
```

Independent check of unit tests by Javier
- [x] OSX:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
