### PR TITLE
Add context manager and decorator to set pm date for testing

### DIFF
--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -504,6 +504,9 @@ def test_proper_motion_date_decorator():
     star2 = agasc.get_star(star_id, date="2000:001")
     for name in star1.colnames:
         assert star1[name] == star2[name]
+    star3 = agasc.get_star(star_id, date="2050:001")
+    assert star1["RA_PMCORR"] != star3["RA_PMCORR"]
+    assert star1["DEC_PMCORR"] != star3["DEC_PMCORR"]
 
 
 @pytest.mark.skipif(NO_MAGS_IN_SUPPLEMENT, reason="no mags in supplement")

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -475,6 +475,37 @@ def test_supplement_get_star():
     assert star2["MAG_ACA_ERR"] != star1["MAG_ACA_ERR"]
 
 
+def test_proper_motion_date_context_manager():
+    star_id = 984622968
+    date1 = "2000:001"
+    with agasc.set_proper_motion_date(date1):
+        star1a = agasc.get_star(star_id)
+    star1b = agasc.get_star(star_id, date=date1)
+    assert star1a["RA_PMCORR"] == star1b["RA_PMCORR"]
+    assert star1a["DEC_PMCORR"] == star1b["DEC_PMCORR"]
+
+    date2 = "2025:001"
+    with agasc.set_proper_motion_date(date2):
+        star2a = agasc.get_star(star_id)
+    star2b = agasc.get_star(star_id, date=date2)
+    assert star2a["RA_PMCORR"] == star2b["RA_PMCORR"]
+    assert star2a["DEC_PMCORR"] == star2b["DEC_PMCORR"]
+
+    assert np.isclose(star1a["RA_PMCORR"], 346.4668294739581, rtol=0, atol=1e-5)
+    assert np.isclose(star1a["DEC_PMCORR"], -35.85307531933251, rtol=0, atol=1e-5)
+    assert np.isclose(star2a["RA_PMCORR"], 346.5247782327743, rtol=0, atol=1e-5)
+    assert np.isclose(star2a["DEC_PMCORR"], -35.843839208221404, rtol=0, atol=1e-5)
+
+
+@agasc.set_proper_motion_date("2000:001")
+def test_proper_motion_date_decorator():
+    star_id = 55725616
+    star1 = agasc.get_star(star_id)
+    star2 = agasc.get_star(star_id, date="2000:001")
+    for name in star1.colnames:
+        assert star1[name] == star2[name]
+
+
 @pytest.mark.skipif(NO_MAGS_IN_SUPPLEMENT, reason="no mags in supplement")
 def test_supplement_get_star_disable_context_manager():
     """Test that disable_supplement_mags context manager works.


### PR DESCRIPTION
## Description

Add context manager and decorator to set date for proper motion for testing

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This seems like an easy way to fix https://github.com/sot/find_attitude/issues/34

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac arm64
```
(ska3-flight-latest) flame:agasc jean$ pytest
=================================================================================== test session starts ====================================================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 79 items                                                                                                                                                                         

agasc/tests/test_agasc_1.py .......                                                                                                                                                  [  8%]
agasc/tests/test_agasc_2.py ..........sssss..........ss....................                                                                                                          [ 68%]
agasc/tests/test_agasc_healpix.py .ssssssssss                                                                                                                                        [ 82%]
agasc/tests/test_obs_status.py ..............                                                                                                                                        [100%]

============================================================================== 62 passed, 17 skipped in 8.01s ==============================================================================
(ska3-flight-latest) flame:agasc jean$ git rev-parse HEAD
e96b9326500d16e052be5b6b4d824575e543ca5d
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
