### PR TITLE
add add_pmcorr_columns to agasc.__all__

### DIFF
--- a/agasc/agasc.py
+++ b/agasc/agasc.py
@@ -35,6 +35,7 @@ __all__ = [
     "write_agasc",
     "TABLE_DTYPE",
     "TableOrder",
+    "add_pmcorr_columns",
 ]
 
 logger = logging.getLogger("agasc")


### PR DESCRIPTION
## Description

This PR just adds `add_pmcorr_columns` to `agasc.__all__`. This is so I can use it from aperoll.

I use this because I do not use the standard `get_agasc_cone` function, and instead get the healpix pixels directly.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
