### PR TITLE
Handle cases where kadi events come from maude

### DIFF
--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -92,6 +92,16 @@ class MagStatsException(Exception):
                 "traceback": "\n".join(stack_trace),
             }
 
+    def _failed_(self):
+        """
+        Check if the exception is a failure.
+
+        :return: bool
+        """
+        return self.error_code > 1
+
+    failed = property(_failed_)
+
     def __str__(self):
         return (
             f"MagStatsException: {self.msg} (agasc_id: {self.agasc_id}, "
@@ -1310,12 +1320,12 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
                 {
                     "obs_ok": False,
                     "obs_suspect": False,
-                    "obs_fail": True,
+                    "obs_fail": e.failed,
                     "comments": comment if excluded_obs[i] else f"Error: {e.msg}.",
                 }
             )
             stats.append(obs_stat)
-            if not excluded_obs[i]:
+            if e.failed and not excluded_obs[i]:
                 logger.debug(
                     f"  Error in get_agasc_id_stats({agasc_id=},"
                     f" obsid={obs['obsid']}): {e}"
@@ -1352,7 +1362,7 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
     if len(all_telem) - len(failures) <= 0:
         # and we reach here if some observations were not flagged as bad, but all failed.
         logger.debug(
-            f"  Error in get_agasc_id_stats({agasc_id=}): There is no OK observation."
+            f"  get_agasc_id_stats({agasc_id=}): There is no OK observation."
         )
         return result, stats, failures
 

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -1361,9 +1361,7 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
 
     if len(all_telem) - len(failures) <= 0:
         # and we reach here if some observations were not flagged as bad, but all failed.
-        logger.debug(
-            f"  get_agasc_id_stats({agasc_id=}): There is no OK observation."
-        )
+        logger.debug(f"  get_agasc_id_stats({agasc_id=}): There is no OK observation.")
         return result, stats, failures
 
     excluded_obs += np.array([t is None for t in all_telem])

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -47,7 +47,6 @@ MASK = {
 
 
 EXCEPTION_MSG = {
-    -1: "Unknown",
     0: "OK",
     1: "No level 0 data",
     2: "No telemetry data",
@@ -55,8 +54,9 @@ EXCEPTION_MSG = {
     4: "Time mismatch between cheta and level0",
     5: "Failed job",
     6: "Suspect observation",
+    1000: "Unknown",
 }
-EXCEPTION_CODES = collections.defaultdict(lambda: -1)
+EXCEPTION_CODES = collections.defaultdict(lambda: 1000)
 EXCEPTION_CODES.update({msg: code for code, msg in EXCEPTION_MSG.items() if code > 0})
 
 


### PR DESCRIPTION
## Description

Since kadi uses maude for events, it is common that an observation will still not have level0 data during supplement processing. This PR changes the handling of _No level 0 data_ so they do not count as failures.

As a consequence of this, some stars might end up having no observations with data, and that should not be considered an error. I therefore changed a log message (`There is no OK observation`) to remove the word "error" from it so it doesn't trip the checks.


## Interface impacts
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
jgonzale agasc $ git rev-parse HEAD
b8f8935fc0c6ebeba5dcac28a605cd4499399cee
jgonzale agasc $ pytest agasc
============================================================= test session starts =============================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 77 items                                                                                                                            

agasc/tests/test_agasc_1.py .......                                                                                                     [  9%]
agasc/tests/test_agasc_2.py .............................................                                                               [ 67%]
agasc/tests/test_agasc_healpix.py ...........                                                                                           [ 81%]
agasc/tests/test_obs_status.py ..............                                                                                           [100%]

======================================================= 77 passed in 132.95s (0:02:12) ========================================================

```

Independent check of unit tests by Jean
- [x] Linux
```
(ska3-latest) jeanconn-fido> pytest
================================================= test session starts =================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.3.1, anyio-4.7.0
collected 77 items                                                                                                    

agasc/tests/test_agasc_1.py .......                                                                             [  9%]
agasc/tests/test_agasc_2.py .............................................                                       [ 67%]
agasc/tests/test_agasc_healpix.py ...........                                                                   [ 81%]
agasc/tests/test_obs_status.py ..............                                                                   [100%]

=========================================== 77 passed in 142.51s (0:02:22) ============================================
(ska3-latest) jeanconn-fido> git rev-parse HEAD
68caf2b9c29eff46aaf91b3c0e97d4e135933e7b
```
### Functional tests

Processed the last day of data using this command:
```
agasc-update-magnitudes --args-file rc/call_args.yml --start 2025:111:00:00:00.000
```
(more details in a readme file in the working directory.

The output for both master and branch is in the following links. Note that in the branch, the problematic observations do not show up in the *Failures* section, and they are highlighted in yellow instead of red:
- [master](https://icxc.cfa.harvard.edu/aspect/test_review_outputs/agasc/pr-196/rc-master/supplement_reports/weekly/2025:112/)
- [branch](https://icxc.cfa.harvard.edu/aspect/test_review_outputs/agasc/pr-196/rc-branch/supplement_reports/weekly/2025:112/)

Checked the logs to verify that no error messages are logged:
```
jgonzale pr-196 $ grep "No level 0 data" rc-master/run.log 
2025-04-22 14:23:04,924   Error in get_agasc_id_stats(agasc_id=805309488, obsid=30442): MagStatsException: No level 0 data (agasc_id: 805309488, obsid: 30442, mp_starcat_time: 2025:111:20:07:49.547)
2025-04-22 14:23:11,766   Error in get_agasc_id_stats(agasc_id=805310584, obsid=30442): MagStatsException: No level 0 data (agasc_id: 805310584, obsid: 30442, mp_starcat_time: 2025:111:20:07:49.547)
2025-04-22 14:23:19,066   Error in get_agasc_id_stats(agasc_id=805310872, obsid=30442): MagStatsException: No level 0 data (agasc_id: 805310872, obsid: 30442, mp_starcat_time: 2025:111:20:07:49.547)
2025-04-22 14:23:26,052   Error in get_agasc_id_stats(agasc_id=805313064, obsid=30442): MagStatsException: No level 0 data (agasc_id: 805313064, obsid: 30442, mp_starcat_time: 2025:111:20:07:49.547)
2025-04-22 14:23:36,084   Error in get_agasc_id_stats(agasc_id=805313512, obsid=30442): MagStatsException: No level 0 data (agasc_id: 805313512, obsid: 30442, mp_starcat_time: 2025:111:20:07:49.547)
jgonzale pr-196 $ grep "No level 0 data" rc-branch/run.log 
```
