### PR TITLE
fix bug causing wrong values of magnitude changes in report

### DIFF
--- a/agasc/scripts/supplement_diff.py
+++ b/agasc/scripts/supplement_diff.py
@@ -24,8 +24,10 @@ def read_file(filename, exclude=None):
     if exclude is None:
         exclude = []
     formats = {
-        "agasc_versions": {k: "{:>21s}" for k in ["mags", "obs", "bad", "supplement"]},
-        "last_updated": {k: "{:>21s}" for k in ["mags", "obs", "bad", "supplement"]},
+        "agasc_versions": dict.fromkeys(
+            ["mags", "obs", "bad", "supplement"], "{:>21s}"
+        ),
+        "last_updated": dict.fromkeys(["mags", "obs", "bad", "supplement"], "{:>21s}"),
         "obs": {"comments": "{:>80s}", "agasc_id": "{:10d}"},
     }
 

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -74,8 +74,8 @@ class MagStatsException(Exception):
             if isinstance(mp_starcat_time, list) and len(mp_starcat_time) == 1
             else mp_starcat_time
         )
-        for k in kwargs:
-            setattr(self, k, kwargs[k])
+        for key, val in kwargs.items():
+            setattr(self, key, val)
 
         exc_type, exc_value, exc_traceback = sys.exc_info()
         if exc_type is None:
@@ -254,7 +254,7 @@ def get_star_position(star, telem):
     zag = np.arctan2(d_aca[:, 2], d_aca[:, 0]) * rad_to_arcsec
 
     logger.debug(
-        f'    star position. AGASC_ID={star["AGASC_ID"]}, '
+        f"    star position. AGASC_ID={star['AGASC_ID']}, "
         f"{len(yag)} samples, ({yag[0]}, {zag[0]})..."
     )
     return {
@@ -318,8 +318,8 @@ def get_telemetry(obs):
     stop = CxoTime(obs["obs_stop"]).cxcsec
     slot = obs["slot"]
     logger.debug(
-        f'  Getting telemetry for AGASC ID={obs["agasc_id"]}, OBSID={obs["obsid"]}, '
-        f'mp_starcat_time={obs["mp_starcat_time"]}'
+        f"  Getting telemetry for AGASC ID={obs['agasc_id']}, OBSID={obs['obsid']}, "
+        f"mp_starcat_time={obs['mp_starcat_time']}"
     )
 
     # first we get slot data from mica and magnitudes from cheta and match them in time
@@ -423,9 +423,9 @@ def get_telemetry(obs):
         & (telem["AOACFCT"] == "TRAK")
     )
 
-    assert len(slot_data) == len(
-        mag_est_ok
-    ), f"len(slot_data) != len(ok) ({len(slot_data)} != {len(mag_est_ok)})"
+    assert len(slot_data) == len(mag_est_ok), (
+        f"len(slot_data) != len(ok) ({len(slot_data)} != {len(mag_est_ok)})"
+    )
 
     # etc...
     logger.debug("    Adding magnitude estimates")
@@ -499,7 +499,7 @@ def get_telemetry_by_agasc_id(agasc_id, obsid=None, ignore_exceptions=False):
             telem.append(t)
         except Exception:
             if not ignore_exceptions:
-                logger.info(f'{agasc_id=}, obsid={o["obsid"]} failed')
+                logger.info(f"{agasc_id=}, obsid={o['obsid']} failed")
                 exc_type, exc_value, exc_traceback = sys.exc_info()
                 trace = traceback.extract_tb(exc_traceback)
                 logger.info(f"{exc_type.__name__} {exc_value}")
@@ -754,8 +754,8 @@ def get_obs_stats(obs, telem=None):
         dictionary with stats
     """
     logger.debug(
-        f'  Getting OBS stats for AGASC ID {obs["agasc_id"]},'
-        f' OBSID {obs["agasc_id"]} at {obs["mp_starcat_time"]}'
+        f"  Getting OBS stats for AGASC ID {obs['agasc_id']},"
+        f" OBSID {obs['agasc_id']} at {obs['mp_starcat_time']}"
     )
 
     star_obs_catalogs.load()
@@ -842,9 +842,9 @@ def get_obs_stats(obs, telem=None):
     if len(telem) > 0:
         stats.update(calc_obs_stats(telem))
         logger.debug(
-            f'    slot={stats["slot"]}, f_ok={stats["f_ok"]:.3f}, '
-            f'f_mag_est_ok={stats["f_mag_est_ok"]:.3f}, f_dr3={stats["f_dr3"]:.3f}, '
-            f'mag={stats["mag_obs"]:.2f}'
+            f"    slot={stats['slot']}, f_ok={stats['f_ok']:.3f}, "
+            f"f_mag_est_ok={stats['f_mag_est_ok']:.3f}, f_dr3={stats['f_dr3']:.3f}, "
+            f"mag={stats['mag_obs']:.2f}"
         )
     return stats
 
@@ -1236,7 +1236,7 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
     if np.any(excluded_obs):
         logger.debug(
             "  Excluding observations flagged in obs-status table: "
-            f'{list(star_obs[excluded_obs]["obsid"])}'
+            f"{list(star_obs[excluded_obs]['obsid'])}"
         )
 
     included_obs = np.array(
@@ -1251,7 +1251,7 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
     if np.any(included_obs):
         logger.debug(
             "  Including observations marked OK in obs-status table: "
-            f'{list(star_obs[included_obs]["obsid"])}'
+            f"{list(star_obs[included_obs]['obsid'])}"
         )
 
     failures = []
@@ -1265,7 +1265,7 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
             status = obs_status_override[(oi, ai)]
             logger.debug(
                 f"  overriding status for (AGASC ID {ai}, starcat time {oi}): "
-                f'{status["status"]}, {status["comments"]}'
+                f"{status['status']}, {status['comments']}"
             )
             comment = status["comments"]
         try:
@@ -1318,7 +1318,7 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
             if not excluded_obs[i]:
                 logger.debug(
                     f"  Error in get_agasc_id_stats({agasc_id=},"
-                    f' obsid={obs["obsid"]}): {e}'
+                    f" obsid={obs['obsid']}): {e}"
                 )
                 failures.append(dict(e))
 
@@ -1365,7 +1365,7 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
         t["obs_ok"] = np.ones_like(t["mag_est_ok"], dtype=bool) * s["obs_ok"]
         logger.debug(
             "  identifying outlying observations "
-            f'(OBSID={s["obsid"]}, mp_starcat_time={s["mp_starcat_time"]})'
+            f"(OBSID={s['obsid']}, mp_starcat_time={s['mp_starcat_time']})"
         )
         t["obs_outlier"] = np.zeros_like(t["mag_est_ok"])
         if np.any(t["mag_est_ok"]) and s["f_mag_est_ok"] > 0 and s["obs_ok"]:
@@ -1532,5 +1532,5 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
         }
     )
 
-    logger.debug(f'  stats for AGASC ID {agasc_id}:  {stats["mag_obs"][0]}')
+    logger.debug(f"  stats for AGASC ID {agasc_id}:  {stats['mag_obs'][0]}")
     return result, stats, failures

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -237,7 +237,7 @@ class MagEstimateReport:
         }
 
         if filename is None:
-            filename = f'mag_estimates_{info["tstart"]}-{info["tstop"]}.html'
+            filename = f"mag_estimates_{info['tstart']}-{info['tstop']}.html"
 
         # this is the list of agasc_id for which we will generate individual reports (if possible)
         if sections:
@@ -325,7 +325,7 @@ class MagEstimateReport:
                 dirname = (
                     self.directory
                     / "stars"
-                    / f"{agasc_id//1e7:03.0f}"
+                    / f"{agasc_id // 1e7:03.0f}"
                     / f"{agasc_id:.0f}"
                 )
                 if make_single_reports:

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -271,6 +271,8 @@ class MagEstimateReport:
         ]
 
         agasc_stats = self.agasc_stats.copy()
+        if not np.all(np.diff(agasc_stats["agasc_id"]) > 0):
+            agasc_stats.sort(keys=["agasc_id"])
 
         # add some extra fields
         if len(agasc_stats):
@@ -297,12 +299,14 @@ class MagEstimateReport:
             agasc_stats["last_obs"] = CxoTime(agasc_stats["last_obs_time"]).date
 
         if len(updated_stars):
-            agasc_stats["update_mag_aca"][
-                np.in1d(agasc_stats["agasc_id"], updated_star_ids)
-            ] = updated_stars["mag_aca"]
-            agasc_stats["update_mag_aca_err"][
-                np.in1d(agasc_stats["agasc_id"], updated_star_ids)
-            ] = updated_stars["mag_aca_err"]
+            in_agasc_stats = np.in1d(updated_stars["agasc_id"], agasc_stats["agasc_id"])
+            if np.any(~in_agasc_stats):
+                raise ValueError(
+                    "ome stars in updated_stars are not not in agasc_stats"
+                )
+            idx1 = np.searchsorted(agasc_stats["agasc_id"], updated_stars["agasc_id"])
+            agasc_stats["update_mag_aca"][idx1] = updated_stars["mag_aca"]
+            agasc_stats["update_mag_aca_err"][idx1] = updated_stars["mag_aca_err"]
 
         tooltips = {
             "warning": "At least one bad observation",

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -300,6 +300,11 @@ class MagEstimateReport:
         if len(updated_stars):
             in_agasc_stats = np.in1d(updated_stars["agasc_id"], agasc_stats["agasc_id"])
             if np.any(~in_agasc_stats):
+                # This should never happen in weekly processing, because updated_stars is created
+                # in update_mag_supplement.update_supplement. If there is an error, it will mean
+                # this function (and this class) is using an outdated agasc_stats file
+                # (mag_stats_agasc.fits by default) which is inconsistent with the passed
+                # updated_stars array.
                 raise ValueError(
                     "Some stars in updated_stars are not not in agasc_stats"
                 )

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -271,8 +271,7 @@ class MagEstimateReport:
         ]
 
         agasc_stats = self.agasc_stats.copy()
-        if not np.all(np.diff(agasc_stats["agasc_id"]) > 0):
-            agasc_stats.sort(keys=["agasc_id"])
+        agasc_stats.sort(keys=["agasc_id"])
 
         # add some extra fields
         if len(agasc_stats):

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -302,7 +302,7 @@ class MagEstimateReport:
             in_agasc_stats = np.in1d(updated_stars["agasc_id"], agasc_stats["agasc_id"])
             if np.any(~in_agasc_stats):
                 raise ValueError(
-                    "ome stars in updated_stars are not not in agasc_stats"
+                    "Some stars in updated_stars are not not in agasc_stats"
                 )
             idx1 = np.searchsorted(agasc_stats["agasc_id"], updated_stars["agasc_id"])
             agasc_stats["update_mag_aca"][idx1] = updated_stars["mag_aca"]

--- a/agasc/tests/test_obs_status.py
+++ b/agasc/tests/test_obs_status.py
@@ -568,15 +568,15 @@ def test_parse_file(monkeypatch, mock_open):
         print("arg:")
         print(data)
         data = update_supplement._sanitize_args(data)
-        assert (
-            data == TEST_DATA[filename]
-        ), f'_parse_obs_status_file("{filename}") == TEST_DATA["{filename}"]'
+        assert data == TEST_DATA[filename], (
+            f'_parse_obs_status_file("{filename}") == TEST_DATA["{filename}"]'
+        )
 
         # _parse_obs_status_file should be idempotent
         data = update_supplement._sanitize_args(data)
-        assert (
-            data == TEST_DATA[filename]
-        ), "update_supplement._sanitize_args should be idempotent"
+        assert data == TEST_DATA[filename], (
+            "update_supplement._sanitize_args should be idempotent"
+        )
 
 
 def test_parse_args_file(monkeypatch, mock_open):
@@ -1303,13 +1303,13 @@ def _monkeypatch_star_obs_catalogs_(monkeypatch, test_file, path):
     ]
 
     res = {t: table.Table.read(test_file, path=f"{path}/cat/{t}") for t in tables}
-    for k in res:
-        res[k].convert_bytestring_to_unicode()
+    for val in res.values():
+        val.convert_bytestring_to_unicode()
     res["STARS_OBS"].add_index("agasc_id")
     res["STARS_OBS"].add_index("mp_starcat_time")
 
-    for k in res:
-        monkeypatch.setattr(star_obs_catalogs, k, res[k])
+    for key, val in res.items():
+        monkeypatch.setattr(star_obs_catalogs, key, val)
 
 
 def _monkeypatch_get_telemetry_(monkeypatch, test_file, path):


### PR DESCRIPTION
## Description

This PR fixes a bug in the agasc supplement report. The report has one section of updated stars, and those updated should have a change in magnitude or magnitude uncertainty of at least 0.01, but the report shows multiple zeros (see picture below).

![agasc_supplement_bug](https://github.com/user-attachments/assets/f65923cb-cda8-4738-8d4e-8e4f17417d15)

There is another section called "Magnitude not Updated", but we see stars with non-zero magnitude changes. This PR fixes that. 


## Interface impacts
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

```
(ska3-flight-2025.1rc1) jgonzale agasc $ git rev-parse --short HEAD
61418f2
(ska3-flight-2025.1rc1) jgonzale agasc $ pytest agasc
======================================================================================================== test session starts ========================================================================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: anyio-4.7.0, dash-2.18.2, timeout-2.3.1
collected 77 items                                                                                                                                                                                                                  

agasc/tests/test_agasc_1.py .......                                                                                                                                                                                           [  9%]
agasc/tests/test_agasc_2.py .............................................                                                                                                                                                     [ 67%]
agasc/tests/test_agasc_healpix.py ...........                                                                                                                                                                                 [ 81%]
agasc/tests/test_obs_status.py ..............                                                                                                                                                                                 [100%]

================================================================================================== 77 passed in 119.74s (0:01:59) ===================================================================================================
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

I ran a fraction of last week's supplement processing. To do this, I copied the `call_args.yml` file from the `latest` supplement report, and changed the stop time to `2025:097:00:00:00.000`. The contents of the file are:
```
agasc_id: null
agasc_id_file: null
agasc_ids: []
args_file: null
bad_star_id: []
bad_star_source: null
comments: ''
dry_run: false
include_bad: false
log_level: debug
mp_starcat_time: null
multi_process: false
no_progress: false
obs_status_file: null
obsid: null
output_dir: /proj/sot/ska/jgonzalez/agasc/pr-198/rc
report: true
report_date: 2025:104:00:00:00.000
reports_dir: /proj/sot/ska/jgonzalez/agasc/pr-198/rc/supplement_reports/weekly
start: 2025:073:22:52:07.740
status: null
stop: 2025:097:00:00:00.000
whole_history: false
```

With this file, I ran `agasc-update-magnitudes --args-file rc/call_args.yml`. The output using the master and the branch versions are linked below:

- [master](https://cxc.cfa.harvard.edu/mta/ASPECT/jgonzalez/agasc/pr-198/rc-master/supplement_reports/weekly/2025:104/)
- [branch](https://cxc.cfa.harvard.edu/mta/ASPECT/jgonzalez/agasc/pr-198/rc-branch/supplement_reports/weekly/2025:104/)
