### PR TITLE
Zero size error

### DIFF
--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -373,6 +373,14 @@ def get_telemetry(obs):
             slot=obs["slot"],
         )
     times = msids[f"AOACMAG{slot}"].times
+    if len(times) == 0:
+        raise MagStatsException(
+            "No telemetry data",
+            agasc_id=obs["agasc_id"],
+            obsid=obs["obsid"],
+            mp_starcat_time=obs["mp_starcat_time"],
+        )
+
     tmin = np.min([np.min(slot_data["END_INTEG_TIME"]), np.min(times)])
     t1 = np.round((times - tmin) / 1.025)
     t2 = np.round((slot_data["END_INTEG_TIME"].data - tmin) / 1.025)
@@ -384,7 +392,7 @@ def get_telemetry(obs):
     if len(times) == 0:
         # the intersection was null.
         raise MagStatsException(
-            "Either no telemetry or no matching times between cheta and level0",
+            "No matching times between cheta and level0",
             agasc_id=obs["agasc_id"],
             obsid=obs["obsid"],
             mp_starcat_time=obs["mp_starcat_time"],

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -765,7 +765,7 @@ def get_obs_stats(obs, telem=None):
     """
     logger.debug(
         f"  Getting OBS stats for AGASC ID {obs['agasc_id']},"
-        f" OBSID {obs['agasc_id']} at {obs['mp_starcat_time']}"
+        f" OBSID {obs['obsid']} at {obs['mp_starcat_time']}"
     )
 
     star_obs_catalogs.load()

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -50,10 +50,8 @@ EXCEPTION_MSG = {
     0: "OK",
     1: "No level 0 data",
     2: "No telemetry data",
-    3: "Mismatch in telemetry between aca_l0 and cheta",
-    4: "Time mismatch between cheta and level0",
-    5: "Failed job",
-    6: "Suspect observation",
+    3: "No matching times between cheta and level0",
+    4: "Suspect observation",
     1000: "Unknown",
 }
 EXCEPTION_CODES = collections.defaultdict(lambda: 1000)


### PR DESCRIPTION
## Description

This PR makes changes so that the following error found recently is properly reported:
```
Unexpected Error: zero-size array to reduction operation minimum which has no identity
```

The specific occurrence of this error is due to missing telemetry. I did not think this could happen, because this happens right after the output from `aca_l0.get_slot_data` is checked. I don't see how one can have slot data and no telemetry.

Actually, it can happen if there is telemetry but `fetch.MSIDset.filter_bad` removes everything, because the telemetry is filtered before checking. I re-ran the script and didn't reproduce the error, so I do not think it is due to filtering. I figure we at least want to label this error from now on.

This actual changes in this PR:
- raise an exception for no telemetry (after filtering)
- updated the "known" exceptions
   - removed messages that are never issued and included "No matching times between cheta and level0" (this message changed and it was never updated)
- fixed a bug where the OBSID was being wrongly reported (it was reporting the AGASC ID instead)

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
