### PR TITLE
Make it so "No telemetry data" is not considered a failure

### DIFF
--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -48,7 +48,7 @@ MASK = {
 
 EXCEPTION_MSG = {
     0: "OK",
-    1: "No level 0 data",
+    1: "No mica archive level 0 data",
     2: "No telemetry data",
     3: "No matching times between cheta and level0",
     4: "Suspect observation",
@@ -363,7 +363,7 @@ def get_telemetry(obs):
     msids.filter_bad(union=True)
     if len(slot_data) == 0:
         raise MagStatsException(
-            "No level 0 data",
+            "No mica archive level 0 data",
             agasc_id=obs["agasc_id"],
             obsid=obs["obsid"],
             mp_starcat_time=obs["mp_starcat_time"],

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -96,7 +96,7 @@ class MagStatsException(Exception):
 
         :return: bool
         """
-        return self.error_code > 1
+        return self.error_code > 2
 
     failed = property(_failed_)
 
@@ -523,7 +523,7 @@ def get_telemetry_by_agasc_id(agasc_id, obsid=None, ignore_exceptions=False):
                     logger.info(f"  in {step.filename}:{step.lineno}/{step.name}:")
                     logger.info(f"    {step.line}")
                 raise
-    return vstack(telem)
+    return vstack(telem) if telem else []
 
 
 def add_obs_info(telem, obs_stats):

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -444,12 +444,16 @@ class MagEstimateReport:
                 # it just means there is no telemetry
                 if e.fail:
                     # if it is some other failure, just notify we are skipping it
-                    logger.debug(f"Skip {agasc_id} in MagEstimateReport.plot_agasc_id_single: {e}")
+                    logger.debug(
+                        f"Skip {agasc_id} in MagEstimateReport.plot_agasc_id_single: {e}"
+                    )
                 telem = []
             except Exception as e:
                 # this is an exception not considered in MagStatsException, so this is not normal
                 # issue a message that triggers a warning in weekly processing
-                logger.debug(f"Unexpected error in MagEstimateReport.plot_agasc_id_single: {e}")
+                logger.debug(
+                    f"Unexpected error in MagEstimateReport.plot_agasc_id_single: {e}"
+                )
                 telem = []
 
         if len(telem) == 0 or (

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -437,9 +437,19 @@ class MagEstimateReport:
                 telem = mag_estimate.get_telemetry_by_agasc_id(
                     agasc_id, ignore_exceptions=True
                 )
-                telem = mag_estimate.add_obs_info(telem, obs_stats)
+                if len(telem) > 0:
+                    telem = mag_estimate.add_obs_info(telem, obs_stats)
+            except mag_estimate.MagStatsException as e:
+                # when there is no telemetry, MagStatsException is raised but is not a failure
+                # it just means there is no telemetry
+                if e.fail:
+                    # if it is some other failure, just notify we are skipping it
+                    logger.debug(f"Skip {agasc_id} in MagEstimateReport.plot_agasc_id_single: {e}")
+                telem = []
             except Exception as e:
-                logger.debug(f"Error making plot: {e}")
+                # this is an exception not considered in MagStatsException, so this is not normal
+                # issue a message that triggers a warning in weekly processing
+                logger.debug(f"Unexpected error in MagEstimateReport.plot_agasc_id_single: {e}")
                 telem = []
 
         if len(telem) == 0 or (
@@ -917,11 +927,21 @@ class MagEstimateReport:
                 telem = mag_estimate.get_telemetry_by_agasc_id(
                     agasc_id, ignore_exceptions=True
                 )
-                telem = mag_estimate.add_obs_info(
-                    telem, self.obs_stats[self.obs_stats["agasc_id"] == agasc_id]
-                )
+                if len(telem) > 0:
+                    telem = mag_estimate.add_obs_info(
+                        telem, self.obs_stats[self.obs_stats["agasc_id"] == agasc_id]
+                    )
+            except mag_estimate.MagStatsException as e:
+                # when there is no telemetry, MagStatsException is raised but is not a failure
+                # it just means there is no telemetry
+                if e.fail:
+                    # if it is some other failure, just notify we are skipping it
+                    logger.debug(f"Skip {agasc_id} in MagEstimateReport.plot_set: {e}")
+                telem = []
             except Exception as e:
-                logger.debug(f"Error making plot: {e}")
+                # this is an exception not considered in MagStatsException, so this is not normal
+                # issue a message that triggers a warning in weekly processing
+                logger.debug(f"Unexpected error in MagEstimateReport.plot_set: {e}")
                 telem = []
 
         if len(telem) == 0:


### PR DESCRIPTION
Make it so "No telemetry data" is not considered a failure, and handle it properly when making the report.

These are the differences with the current flight version: https://github.com/sot/agasc/compare/4.23.0...no-telem

It is possible that observations that gave the no-telemetry error in previous weeks might have been skipped in later updates. This would only happen with stars that were already in the supplement and were updated while giving the no-telemetry error (meaning the observation giving the error will be older than the last update). I would not loose sleep over these. See examples in functional test below.

## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes handling "no telemetry data" as failure.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
jgonzale agasc $ git rev-parse HEAD
56b8f4e176d7544d73211529a134b0edcc4d9127
jgonzale agasc $ pytest agasc
==================================================================== test session starts =====================================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 77 items                                                                                                                                           

agasc/tests/test_agasc_1.py .......                                                                                                                    [  9%]
agasc/tests/test_agasc_2.py .............................................                                                                              [ 67%]
agasc/tests/test_agasc_healpix.py ...........                                                                                                          [ 81%]
agasc/tests/test_obs_status.py ..............                                                                                                          [100%]

=============================================================== 77 passed in 154.27s (0:02:34) ===============================================================
```

Independent check of unit tests by Jean
- [x] Linux
```
(ska3-latest) jeanconn-kady> pytest
====================================================================================== test session starts ======================================================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 77 items                                                                                                                                                                              

agasc/tests/test_agasc_1.py .......                                                                                                                                                       [  9%]
agasc/tests/test_agasc_2.py .............................................                                                                                                                 [ 67%]
agasc/tests/test_agasc_healpix.py ...........                                                                                                                                             [ 81%]
agasc/tests/test_obs_status.py ..............                                                                                                                                             [100%]

================================================================================ 77 passed in 130.68s (0:02:10) =================================================================================
(ska3-latest) jeanconn-kady> git rev-parse HEAD
2c366bdc4a1cd9b7fbabcb715dc12b516998004a
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

The version in this PR has been running in a weekly cron job. A comparison between [flight](https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement_reports/weekly/latest/) and [this branch](https://cxc.cfa.harvard.edu/mta/ASPECT/jgonzalez/agasc/aca/supplement_reports/weekly/latest/) agasc supplement report yields the following differences:
- Many stars have small numerical differences. I do not think this is caused by this PR. Some other package must be causing this. You can see that the magnitude values in plots are slightly different, and this PR does not touch any of that.
- all the yellow rows in the flight report are white in the branch, because the observations causing no-telemetry errors are ignored.
- 21 stars in flight and not in the branch. These are stars in OBSIDS that still had no telemetry and produce an error in flight. These are correctly not shown in the branch:
   - OBSID [42112](https://web-kadi.cfa.harvard.edu/mica/?obsid_or_date=42112): 133224, 133416, 136104, 137336, 141784
   - OBSID [42110](https://web-kadi.cfa.harvard.edu/mica/?obsid_or_date=42110): 715005712, 715010592, 788137016, 788137896, 788138136, 788139272, 788139648, 788151256
   - OBSID [42111](https://web-kadi.cfa.harvard.edu/mica/?obsid_or_date=42111): 326764272, 326768704, 326769288, 327164552, 327165800, 327168680, 327169160, 327299424
- 5 stars in the branch and not in flight. All these stars were in last week's processing but were not updated because of no telemetry, and **for some reason the flight processing missed them this week**. I did not expect this. I'm guessing that these observations were processed and the values differed from the supplement values, and therefore were updated. Then this week the processing script checked for observations since the last update date. There were none, so no update.
  - ID 626524448. [branch](https://cxc.cfa.harvard.edu/mta/ASPECT/jgonzalez/agasc/aca/supplement_reports/weekly/latest/stars/062/626524448/index.html) [flight](https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement_reports/weekly/2025:258/stars/062/626524448/index.html)
  - ID 688262408. [branch](https://cxc.cfa.harvard.edu/mta/ASPECT/jgonzalez/agasc/aca/supplement_reports/weekly/latest/stars/068/688262408/index.html) [flight](https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement_reports/weekly/2025:258/stars/068/688262408/index.html)
  - ID 688265464. [branch](https://cxc.cfa.harvard.edu/mta/ASPECT/jgonzalez/agasc/aca/supplement_reports/weekly/latest/stars/068/688265464/index.html) [flight](https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement_reports/weekly/2025:258/stars/068/688265464/index.html)
  - ID 688265400. [branch](https://cxc.cfa.harvard.edu/mta/ASPECT/jgonzalez/agasc/aca/supplement_reports/weekly/latest/stars/068/688265400/index.html) [flight](https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement_reports/weekly/2025:258/stars/068/688265400/index.html)
  - ID 688266760. [branch](https://cxc.cfa.harvard.edu/mta/ASPECT/jgonzalez/agasc/aca/supplement_reports/weekly/latest/stars/068/688266760/index.html) [flight](https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement_reports/weekly/2025:258/stars/068/688266760/index.html)

