### PR TITLE
Updates for numpy 2

### DIFF
--- a/agasc/scripts/mag_estimate_report.py
+++ b/agasc/scripts/mag_estimate_report.py
@@ -101,7 +101,7 @@ def main():
     stars = np.unique(obs_stats[ok]["agasc_id"])
     sections = [{"id": "stars", "title": "Stars", "stars": stars}]
 
-    agasc_stats = agasc_stats[np.in1d(agasc_stats["agasc_id"], stars)]
+    agasc_stats = agasc_stats[np.isin(agasc_stats["agasc_id"], stars)]
 
     if args.weekly_report:
         t = CxoTime(args.stop)

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -439,9 +439,9 @@ def get_telemetry(obs):
         & (telem["AOACFCT"] == "TRAK")
     )
 
-    assert len(slot_data) == len(
-        mag_est_ok
-    ), f"len(slot_data) != len(ok) ({len(slot_data)} != {len(mag_est_ok)})"
+    assert len(slot_data) == len(mag_est_ok), (
+        f"len(slot_data) != len(ok) ({len(slot_data)} != {len(mag_est_ok)})"
+    )
 
     # etc...
     logger.debug("    Adding magnitude estimates")

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -400,7 +400,7 @@ def get_telemetry(obs):
     telem = {"times": times}
     telem.update({k: slot_data[k] for k in slot_data_cols[2:]})
     telem.update(
-        {name: msids[name].vals[np.in1d(msids[name].times, times)] for name in names}
+        {name: msids[name].vals[np.isin(msids[name].times, times)] for name in names}
     )
 
     # get the normal sun and safe sun mode intervals, which will be removed
@@ -439,9 +439,9 @@ def get_telemetry(obs):
         & (telem["AOACFCT"] == "TRAK")
     )
 
-    assert len(slot_data) == len(mag_est_ok), (
-        f"len(slot_data) != len(ok) ({len(slot_data)} != {len(mag_est_ok)})"
-    )
+    assert len(slot_data) == len(
+        mag_est_ok
+    ), f"len(slot_data) != len(ok) ({len(slot_data)} != {len(mag_est_ok)})"
 
     # etc...
     logger.debug("    Adding magnitude estimates")

--- a/agasc/supplement/magnitudes/mag_estimate_report.py
+++ b/agasc/supplement/magnitudes/mag_estimate_report.py
@@ -252,7 +252,7 @@ class MagEstimateReport:
                     "id": "other_stars",
                     "title": "Other Stars",
                     "stars": self.agasc_stats["agasc_id"][
-                        ~np.in1d(self.agasc_stats["agasc_id"], agasc_ids)
+                        ~np.isin(self.agasc_stats["agasc_id"], agasc_ids)
                     ],
                 }
             )
@@ -290,7 +290,7 @@ class MagEstimateReport:
                 agasc_stats["t_mean_dr3"] - agasc_stats["mag_aca"]
             ) / agasc_stats["mag_aca_err"]
             agasc_stats["new"] = True
-            agasc_stats["new"][np.in1d(agasc_stats["agasc_id"], updated_star_ids)] = (
+            agasc_stats["new"][np.isin(agasc_stats["agasc_id"], updated_star_ids)] = (
                 False
             )
             agasc_stats["update_mag_aca"] = np.nan
@@ -298,7 +298,7 @@ class MagEstimateReport:
             agasc_stats["last_obs"] = CxoTime(agasc_stats["last_obs_time"]).date
 
         if len(updated_stars) > 0:
-            in_agasc_stats = np.in1d(updated_stars["agasc_id"], agasc_stats["agasc_id"])
+            in_agasc_stats = np.isin(updated_stars["agasc_id"], agasc_stats["agasc_id"])
             if np.any(~in_agasc_stats):
                 # This should never happen in weekly processing, because updated_stars is created
                 # in update_mag_supplement.update_supplement. If there is an error, it will mean
@@ -349,7 +349,7 @@ class MagEstimateReport:
         sections = [section for section in sections if len(section["stars"])]
         for section in sections:
             section["stars"] = agasc_stats[
-                np.in1d(agasc_stats["agasc_id"], section["stars"])
+                np.isin(agasc_stats["agasc_id"], section["stars"])
             ].as_array()
 
         # this is a hack
@@ -538,7 +538,7 @@ class MagEstimateReport:
         # set flags for different categories of markers
         highlighted = np.zeros(len(timeline["times"]), dtype=bool)
         if highlight_obsid:
-            highlighted = highlighted | np.in1d(timeline["obsid"], highlight_obsid)
+            highlighted = highlighted | np.isin(timeline["obsid"], highlight_obsid)
         if highlight_outliers:
             highlighted = highlighted | timeline["obs_outlier"]
 

--- a/agasc/supplement/magnitudes/star_obs_catalogs.py
+++ b/agasc/supplement/magnitudes/star_obs_catalogs.py
@@ -27,7 +27,7 @@ def get_star_observations(start=None, stop=None, obsid=None):
     catalogs = commands.get_starcats_as_table(
         start=start, stop=stop, obsid=obsid, unique=True
     )
-    catalogs = catalogs[np.in1d(catalogs["type"], ["BOT", "GUI"])]
+    catalogs = catalogs[np.isin(catalogs["type"], ["BOT", "GUI"])]
     star_obs = join(observations, catalogs, keys=join_keys)
     star_obs.rename_columns(["id", "starcat_date"], ["agasc_id", "mp_starcat_time"])
     star_obs["row"], star_obs["col"] = yagzag_to_pixels(

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -343,7 +343,7 @@ def update_supplement(agasc_stats, filename, include_all=True, d_mag_threshold=0
                 updated_stars["agasc_id"] = new["agasc_id"]
 
                 # find agasc_ids in new list but not in current list
-                new_stars = ~np.in1d(
+                new_stars = ~np.isin(
                     outliers_new["agasc_id"], outliers_current["agasc_id"]
                 )
 
@@ -547,7 +547,7 @@ def do(
 
     agasc_ids = np.unique(agasc_ids)
     stars_obs = star_obs_catalogs.STARS_OBS[
-        np.in1d(star_obs_catalogs.STARS_OBS["agasc_id"], agasc_ids)
+        np.isin(star_obs_catalogs.STARS_OBS["agasc_id"], agasc_ids)
     ]
 
     # if supplement exists:
@@ -562,7 +562,7 @@ def do(
             if not include_bad and "bad" in h5.root:
                 logger.info("Excluding bad stars")
                 stars_obs = stars_obs[
-                    ~np.in1d(stars_obs["agasc_id"], h5.root.bad[:]["agasc_id"])
+                    ~np.isin(stars_obs["agasc_id"], h5.root.bad[:]["agasc_id"])
                 ]
 
             if "obs" in h5.root:
@@ -611,7 +611,7 @@ def do(
                         )
 
                     stars_obs = stars_obs[
-                        np.in1d(stars_obs["agasc_id"], times[update]["agasc_id"])
+                        np.isin(stars_obs["agasc_id"], times[update]["agasc_id"])
                     ]
                     agasc_ids = np.sort(np.unique(stars_obs["agasc_id"]))
                     if len(update) - np.sum(update):
@@ -757,8 +757,8 @@ def do(
                     "title": "Other (unexpectedly not updated)",
                     "stars": list(
                         agasc_stats["agasc_id"][
-                            ~np.in1d(agasc_stats["agasc_id"], new_stars)
-                            & ~np.in1d(
+                            ~np.isin(agasc_stats["agasc_id"], new_stars)
+                            & ~np.isin(
                                 agasc_stats["agasc_id"], updated_stars["agasc_id"]
                             )
                         ]

--- a/agasc/supplement/utils.py
+++ b/agasc/supplement/utils.py
@@ -265,9 +265,9 @@ def update_table(filename, table, path, dtype, keys, dry_run=False, create=False
     i, j = np.argwhere(intersect).T
 
     # entries not yet in supplement
-    append = ~np.in1d(table[keys[0]], suppl_table[keys[0]])
+    append = ~np.isin(table[keys[0]], suppl_table[keys[0]])
     for key in keys[1:]:
-        append |= ~np.in1d(table[key], suppl_table[key])
+        append |= ~np.isin(table[key], suppl_table[key])
     k = np.argwhere(append).T
 
     if not len(i) and not len(k[0]):

--- a/agasc/tests/test_agasc_2.py
+++ b/agasc/tests/test_agasc_2.py
@@ -133,7 +133,7 @@ MINIAGASC_1P7 = agasc.get_agasc_filename("miniagasc_*", version="1p7")
 
 
 def get_ds_agasc_cone(ra, dec):
-    cmd = "mp_get_agasc -r {!r} -d {!r} -w {!r}".format(ra, dec, TEST_RADIUS)
+    cmd = "mp_get_agasc -r {} -d {} -w {}".format(ra, dec, TEST_RADIUS)
     lines = Ska.Shell.tcsh(cmd, env=ascds_env)
     dat = ascii.read(lines, format="no_header", names=AGASC_COLNAMES)
 
@@ -362,7 +362,7 @@ def test_add_pmcorr_is_consistent(agasc_id, date, ra_pmcorr, dec_pmcorr, label):
 
 
 def mp_get_agascid(agasc_id):
-    cmd = "mp_get_agascid {!r}".format(agasc_id)
+    cmd = "mp_get_agascid {}".format(agasc_id)
     lines = Ska.Shell.tcsh(cmd, env=ascds_env)
     lines = [line for line in lines if re.match(r"^\s*\d", line)]
     dat = ascii.read(lines, format="no_header", names=AGASC_COLNAMES)

--- a/agasc/tests/test_obs_status.py
+++ b/agasc/tests/test_obs_status.py
@@ -1227,10 +1227,10 @@ def test_override(monkeypatch):
         agasc_stats["n_obsids_suspect"] == 2
     )  # two suspect count as "fail" in this context
     assert not np.isclose(
-        np.mean(telem[np.in1d(telem["obsid"], [12800])]["mags"]), agasc_stats["mag_obs"]
+        np.mean(telem[np.isin(telem["obsid"], [12800])]["mags"]), agasc_stats["mag_obs"]
     )
     assert np.isclose(
-        np.mean(telem[np.in1d(telem["obsid"], [12800, 23682, 23683])]["mags"]),
+        np.mean(telem[np.isin(telem["obsid"], [12800, 23682, 23683])]["mags"]),
         agasc_stats["mag_obs"],
     )
 
@@ -1253,10 +1253,10 @@ def test_override(monkeypatch):
         agasc_stats["n_obsids_suspect"] == 0
     )  # no fails because all status==1 skipped
     assert np.isclose(
-        np.mean(telem[np.in1d(telem["obsid"], [12800])]["mags"]), agasc_stats["mag_obs"]
+        np.mean(telem[np.isin(telem["obsid"], [12800])]["mags"]), agasc_stats["mag_obs"]
     )
     assert not np.isclose(
-        np.mean(telem[np.in1d(telem["obsid"], [12800, 23682, 23683])]["mags"]),
+        np.mean(telem[np.isin(telem["obsid"], [12800, 23682, 23683])]["mags"]),
         agasc_stats["mag_obs"],
     )
 
@@ -1276,7 +1276,7 @@ def test_override(monkeypatch):
     assert agasc_stats["n_obsids_ok"] == 3
     assert agasc_stats["n_obsids_suspect"] == 1  # one failed
     assert np.isclose(
-        np.mean(telem[np.in1d(telem["obsid"], [12800, 23681, 23683])]["mags"]),
+        np.mean(telem[np.isin(telem["obsid"], [12800, 23681, 23683])]["mags"]),
         agasc_stats["mag_obs"],
     )
 
@@ -1346,7 +1346,7 @@ def recreate_mag_stats_test_data(filename=TEST_DATA_DIR / "mag-stats.h5"):
         "2018:296:15:53:14.596",
     ]
     STARS_OBS = star_obs_catalogs.STARS_OBS[
-        np.in1d(star_obs_catalogs.STARS_OBS["mp_starcat_time"], mp_starcat_time)
+        np.isin(star_obs_catalogs.STARS_OBS["mp_starcat_time"], mp_starcat_time)
     ]
     STARS_OBS = STARS_OBS.group_by("agasc_id")
     STARS_OBS.add_index("agasc_id")


### PR DESCRIPTION
## Description

This addresses issues encountered after upgrading numpy to version 2:
- The repr method for some types changed, change format used to pass arguments to mp_get_agasc in test_agasc_2
- `np.in1d` is deprecated

A quick comment: numpy 2 is correct, because the ideal __repr__() implementation should return a string that, when passed to eval(), would reconstruct an object equal to the original.

In python 3.12 and numpy 1.26.4:
```python
In [1]: import numpy as np
   ...: a = np.int32(1)
   ...: repr(a)
   ...: 
Out[1]: '1'
```

in python 3.13 and numpy 2.3.5
```
In [1]: import numpy as np
   ...: a = np.int32(1)
   ...: repr(a)
   ...: 
Out[1]: 'np.int32(1)'
```

This causes issues in agasc tests, because some values are passed to a command line using a format like
```
mp_get_agascid {!r}".format(agasc_id)
```
this causes the format to be applied on `repr(agasc_id)` which now will be `'np.int32(1)'`


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
(ska3-flight) jgonzale agasc $ git rev-parse HEAD
ecb66c99af703a0f521df34629308af3b88d5b30
(ska3-flight) jgonzale agasc $ pytest agasc
==================================================================== test session starts =====================================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 79 items                                                                                                                                           

agasc/tests/test_agasc_1.py .......                                                                                                                    [  8%]
agasc/tests/test_agasc_2.py ...............................................                                                                            [ 68%]
agasc/tests/test_agasc_healpix.py ...........                                                                                                          [ 82%]
agasc/tests/test_obs_status.py ..............                                                                                                          [100%]

=============================================================== 79 passed in 148.81s (0:02:28) ===============================================================
(ska3-flight) jgonzale agasc $ conda activate ska3-flight-2026.0rc4
(ska3-flight-2026.0rc4) jgonzale agasc $ pytest agasc
==================================================================== test session starts =====================================================================
platform linux -- Python 3.13.10, pytest-9.0.1, pluggy-1.6.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: timeout-2.4.0, anyio-4.12.0
collected 79 items                                                                                                                                           

agasc/tests/test_agasc_1.py .......                                                                                                                    [  8%]
agasc/tests/test_agasc_2.py ...............................................                                                                            [ 68%]
agasc/tests/test_agasc_healpix.py ...........                                                                                                          [ 82%]
agasc/tests/test_obs_status.py ..............                                                                                                          [100%]

=============================================================== 79 passed in 110.20s (0:01:50) ===============================================================

```

Independent check of unit tests by Jean
- [x] Linux ska3/flight pre-hope
```
ska3-jeanconn-kady> git rev-parse HEAD
ecb66c99af703a0f521df34629308af3b88d5b30
ska3-jeanconn-kady> pytest
============================================================ test session starts ============================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 79 items                                                                                                                          

agasc/tests/test_agasc_1.py .......                                                                                                   [  8%]
agasc/tests/test_agasc_2.py ...............................................                                                           [ 68%]
agasc/tests/test_agasc_healpix.py ...........                                                                                         [ 82%]
agasc/tests/test_obs_status.py ..............                                                                                         [100%]

====================================================== 79 passed in 179.50s (0:02:59)
```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
