### PR TITLE
Refactor observation statistics processing and discard recent observations without telemetry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.5.1
+  rev: v0.14.13
   hooks:
     # Run the linter.
     - id: ruff

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -516,6 +516,13 @@ def get_telemetry_by_agasc_id(
     )
 
 
+def _has_error(telem):
+    # error entries produced by get_telemetry_by_observations are plain dicts;
+    # successful telemetry can be a dict or an astropy Table, and
+    # `"error_code" in <Table>` raises TypeError under numpy >= 2
+    return isinstance(telem, dict) and "error_code" in telem
+
+
 def get_telemetry_by_observations(observations, ignore_exceptions=False, as_table=True):
     telem = []
     for obs in observations:
@@ -560,7 +567,7 @@ def get_telemetry_by_observations(observations, ignore_exceptions=False, as_tabl
         # we ignore entries with error_code here because this means ignore_exceptions is true
         # (otherwise the exception would have been raised already)
         return (
-            vstack([Table(tel) for tel in telem if "error_code" not in tel])
+            vstack([Table(tel) for tel in telem if not _has_error(tel)])
             if as_table
             else telem
         )
@@ -1233,8 +1240,7 @@ def get_agasc_id_stats(
     # discard observations with no telemetry if they occured in the last two weeks.
     discard = np.array(
         [
-            ("error_code" in tlm)
-            and (tlm["mp_starcat_time"] > CxoTime() - no_telem_time)
+            _has_error(tlm) and (tlm["mp_starcat_time"] > CxoTime() - no_telem_time)
             for tlm in all_telem
         ]
     )
@@ -1649,7 +1655,7 @@ def get_multi_obs_stats(star_obs, telem=None, obs_status_override=None):
             comment = status["comments"]
 
         obs_telem = telem[i]
-        if "error_code" in obs_telem:
+        if _has_error(obs_telem):
             fail = obs_telem["error_code"] > 2
             obs_stat = get_obs_stats(obs, telem=[])
             obs_stat.update(

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -1258,6 +1258,10 @@ def get_agasc_id_stats(
         stats["w"] = np.array([])
         stats["mean_corrected"] = np.array([])
         stats["weighted_mean"] = np.array([])
+        weighted_mean = {
+            "mag_weighted_mean": [],
+            "mag_weighted_std": [],
+        }
 
     star = get_star(agasc_id, use_supplement=False)
 

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -481,7 +481,9 @@ def get_telemetry(obs):
     return telem
 
 
-def get_telemetry_by_agasc_id(agasc_id, obsid=None, ignore_exceptions=False):
+def get_telemetry_by_agasc_id(
+    agasc_id, obsid=None, ignore_exceptions=False, as_table=True
+):
     """
     Get all telemetry relevant for the magnitude estimation, given an AGASC ID.
 
@@ -491,10 +493,13 @@ def get_telemetry_by_agasc_id(agasc_id, obsid=None, ignore_exceptions=False):
     :param obsid: int (optional)
     :param ignore_exceptions: bool
         if True, any exception is ignored. Useful in some cases. Default is False.
+    :param as_table: bool
+        if True, the telemetry is returned as an astropy Table. If False, it is returned as a list
+        of dicts, one per observation. Default is True.
     :return: dict
     """
     logger.debug(f"  Getting telemetry for AGASC ID={agasc_id}")
-    star_obs_catalogs.load()
+    star_obs_catalogs.load()  # should this be here?
     if obsid is None:
         obs = star_obs_catalogs.STARS_OBS[
             (star_obs_catalogs.STARS_OBS["agasc_id"] == agasc_id)
@@ -505,25 +510,48 @@ def get_telemetry_by_agasc_id(agasc_id, obsid=None, ignore_exceptions=False):
             & (star_obs_catalogs.STARS_OBS["obsid"] == obsid)
         ]
     obs.sort("mp_starcat_time")
+    return get_telemetry_by_observations(
+        obs, ignore_exceptions=ignore_exceptions, as_table=as_table
+    )
 
+
+def get_telemetry_by_observations(observations, ignore_exceptions=False, as_table=True):
     telem = []
-    for _i, o in enumerate(obs):
+    for obs in observations:
+        agasc_id = obs["agasc_id"]
         try:
-            t = Table(get_telemetry(o))
-            t["obsid"] = o["obsid"]
-            t["agasc_id"] = agasc_id
+            t = get_telemetry(obs)
+            t["obsid"] = obs["obsid"] * np.ones(len(t["times"]), dtype=int)
+            t["agasc_id"] = agasc_id * np.ones(len(t["times"]), dtype=int)
             telem.append(t)
+        except MagStatsException as exc:
+            if ignore_exceptions:
+                telem.append(dict(exc))
+            else:
+                logger.info(f"{agasc_id=}, obsid={obs['obsid']} failed")
+                logger.info(f"{exc.exception['name']} {exc.exception['value']}")
+                for step in exc.exception["traceback"]:
+                    logger.info(step)
         except Exception:
-            if not ignore_exceptions:
-                logger.info(f"{agasc_id=}, obsid={o['obsid']} failed")
-                exc_type, exc_value, exc_traceback = sys.exc_info()
-                trace = traceback.extract_tb(exc_traceback)
-                logger.info(f"{exc_type.__name__} {exc_value}")
-                for step in trace:
-                    logger.info(f"  in {step.filename}:{step.lineno}/{step.name}:")
-                    logger.info(f"    {step.line}")
+            exc = MagStatsException(
+                msg="Unknown",
+                agasc_id=obs["agasc_id"],
+                obsid=obs["obsid"],
+                mp_starcat_time=obs["mp_starcat_time"],
+            )
+            if ignore_exceptions:
+                telem.append(dict(exc))
+            else:
+                logger.info(f"{agasc_id=}, obsid={obs['obsid']} failed")
+                logger.info(f"{exc.exception['name']} {exc.exception['value']}")
+                for step in exc.exception["traceback"]:
+                    logger.info(step)
                 raise
-    return vstack(telem) if telem else []
+
+    if telem:
+        return vstack([Table(tel) for tel in telem]) if as_table else telem
+
+    return []
 
 
 def add_obs_info(telem, obs_stats):
@@ -797,6 +825,7 @@ def get_obs_stats(obs, telem=None):
             "mag_aca_err": star["MAG_ACA_ERR"] / 100,
             "row": obs["row"],
             "col": obs["col"],
+            "obs_ok": False,
         }
     )
 
@@ -862,6 +891,13 @@ def get_obs_stats(obs, telem=None):
             f"f_mag_est_ok={stats['f_mag_est_ok']:.3f}, f_dr3={stats['f_dr3']:.3f}, "
             f"mag={stats['mag_obs']:.2f}"
         )
+
+    stats["obs_ok"] = (
+        (stats["n"] > 10)
+        & (stats["f_mag_est_ok"] > 0.3)
+        & (stats["lf_variability_100s"] < 1)
+    )
+
     return stats
 
 
@@ -1168,6 +1204,55 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
     ]
     star_obs.sort("mp_starcat_time")
 
+    n_obsids = len(star_obs)
+
+    all_telem = get_telemetry_by_observations(
+        star_obs, ignore_exceptions=True, as_table=False
+    )
+    stats, failures = get_multi_obs_stats(
+        star_obs, obs_status_override=obs_status_override, telem=all_telem
+    )
+
+    # combine magnitude estimates using a weighted mean
+    weighted_mean = get_weighted_mean(stats)
+    stats["w"] = weighted_mean["weights"]
+    stats["mean_corrected"] = weighted_mean["mean_corrected"]
+    stats["weighted_mean"] = weighted_mean["weighted_mean"]
+
+    star = get_star(agasc_id, use_supplement=False)
+
+    # still need to check that this is the same as before
+    last_obs_time = CxoTime(stats["mp_starcat_time"][-1]).cxcsec
+
+    logger.debug("  identifying outlying observations...")
+    for s, t in zip(stats, all_telem, strict=True):
+        if s["no_telem"] or s["excluded"]:
+            continue
+        t["obs_ok"] = np.ones_like(t["mag_est_ok"], dtype=bool) * s["obs_ok"]
+        logger.debug(
+            "  identifying outlying observations "
+            f"(OBSID={s['obsid']}, mp_starcat_time={s['mp_starcat_time']})"
+        )
+        t["obs_outlier"] = np.zeros_like(t["mag_est_ok"])
+        if np.any(t["mag_est_ok"]) and s["f_mag_est_ok"] > 0 and s["obs_ok"]:
+            iqr = s["q75"] - s["q25"]
+            t["obs_outlier"] = (
+                t["mag_est_ok"]
+                & (iqr > 0)
+                & (
+                    (t["mags"] < s["q25"] - 1.5 * iqr)
+                    | (t["mags"] > s["q75"] + 1.5 * iqr)
+                )
+            )
+
+    all_telem = [
+        Table(t)
+        for s, t in zip(stats, all_telem, strict=True)
+        if not s["excluded"] and not s["no_telem"]
+    ]
+    if len(all_telem) > 0:
+        all_telem = vstack(all_telem)
+
     # this is the default result, if nothing gets calculated
     result = {
         "last_obs_time": 0,
@@ -1196,8 +1281,8 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
         "sigma_plus": 0,
         "mean": 0,
         "std": 0,
-        "mag_weighted_mean": 0,
-        "mag_weighted_std": 0,
+        "mag_weighted_mean": weighted_mean["mag_weighted_mean"],
+        "mag_weighted_std": weighted_mean["mag_weighted_std"],
         "t_mean": 0,
         "t_std": 0,
         "n_outlier": 0,
@@ -1212,12 +1297,30 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
         "selected_rtol": False,
         "selected_mag_aca_err": False,
         "selected_color": False,
-        "f_mag_est_ok": 0,
-        "f_mag_est_ok_3": 0,
-        "f_mag_est_ok_5": 0,
-        "f_ok_3": 0,
-        "f_ok_5": 0,
+        "f_mag_est_ok": 0.0,
+        "f_mag_est_ok_3": 0.0,
+        "f_mag_est_ok_5": 0.0,
+        "f_ok_3": 0.0,
+        "f_ok_5": 0.0,
     }
+
+    # this can be moved up
+    result.update(
+        {
+            "color": star["COLOR1"],
+            "last_obs_time": last_obs_time,
+            "mag_aca": star["MAG_ACA"],
+            "mag_aca_err": star["MAG_ACA_ERR"] / 100,
+            "mag_obs_err": min_mag_obs_err,
+            "n_obsids_fail": len(failures),
+            "n": len(all_telem),
+            "n_obsids_suspect": np.count_nonzero(stats["obs_suspect"]),
+            "n_obsids": n_obsids,
+            "n_obsids_ok": np.count_nonzero(stats["obs_ok"]),
+            "n_no_mag": np.count_nonzero((~stats["obs_ok"]))
+            + np.count_nonzero(stats["f_mag_est_ok"][stats["obs_ok"]] < 0.3),
+        }
+    )
 
     for tag in ["dr3", "dbox5"]:
         result.update(
@@ -1237,127 +1340,8 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
             }
         )
 
-    n_obsids = len(star_obs)
-
-    # exclude star_obs that are in obs_status_override with status != 0
-    excluded_obs = np.array(
-        [
-            (
-                (oi, ai) in obs_status_override
-                and obs_status_override[(oi, ai)]["status"] != 0
-            )
-            for oi, ai in star_obs[["mp_starcat_time", "agasc_id"]]
-        ]
-    )
-    if np.any(excluded_obs):
-        logger.debug(
-            "  Excluding observations flagged in obs-status table: "
-            f"{list(star_obs[excluded_obs]['obsid'])}"
-        )
-
-    included_obs = np.array(
-        [
-            (
-                (oi, ai) in obs_status_override
-                and obs_status_override[(oi, ai)]["status"] == 0
-            )
-            for oi, ai in star_obs[["mp_starcat_time", "agasc_id"]]
-        ]
-    )
-    if np.any(included_obs):
-        logger.debug(
-            "  Including observations marked OK in obs-status table: "
-            f"{list(star_obs[included_obs]['obsid'])}"
-        )
-
-    failures = []
-    all_telem = []
-    stats = []
-    last_obs_time = 0
-    for i, obs in enumerate(star_obs):
-        oi, ai = obs["mp_starcat_time", "agasc_id"]
-        comment = ""
-        if (oi, ai) in obs_status_override:
-            status = obs_status_override[(oi, ai)]
-            logger.debug(
-                f"  overriding status for (AGASC ID {ai}, starcat time {oi}): "
-                f"{status['status']}, {status['comments']}"
-            )
-            comment = status["comments"]
-        try:
-            last_obs_time = CxoTime(obs["mp_starcat_time"]).cxcsec
-            telem = Table(get_telemetry(obs))
-            obs_stat = get_obs_stats(obs, telem={k: telem[k] for k in telem.colnames})
-            obs_stat.update(
-                {
-                    "obs_ok": included_obs[i]
-                    | (
-                        ~excluded_obs[i]
-                        & (obs_stat["n"] > 10)
-                        & (obs_stat["f_mag_est_ok"] > 0.3)
-                        & (obs_stat["lf_variability_100s"] < 1)
-                    ),
-                    "obs_suspect": False,
-                    "obs_fail": False,
-                    "comments": comment,
-                }
-            )
-            all_telem.append(telem)
-            stats.append(obs_stat)
-
-            if not obs_stat["obs_ok"] and not excluded_obs[i]:
-                obs_stat["obs_suspect"] = True
-                failures.append(
-                    dict(
-                        MagStatsException(
-                            msg="Suspect observation",
-                            agasc_id=obs["agasc_id"],
-                            obsid=obs["obsid"],
-                            mp_starcat_time=obs["mp_starcat_time"],
-                        )
-                    )
-                )
-        except MagStatsException as e:
-            # this except branch deals with exceptions thrown by get_telemetry
-            all_telem.append(None)
-            # length-zero telemetry short-circuits any new call to get_telemetry
-            obs_stat = get_obs_stats(obs, telem=[])
-            obs_stat.update(
-                {
-                    "obs_ok": False,
-                    "obs_suspect": False,
-                    "obs_fail": e.failed,
-                    "comments": comment if excluded_obs[i] else f"Error: {e.msg}.",
-                }
-            )
-            stats.append(obs_stat)
-            if e.failed and not excluded_obs[i]:
-                logger.debug(
-                    f"  Error in get_agasc_id_stats({agasc_id=},"
-                    f" obsid={obs['obsid']}): {e}"
-                )
-                failures.append(dict(e))
-
-    stats = Table(stats)
-    stats["w"] = np.nan
-    stats["mean_corrected"] = np.nan
-    stats["weighted_mean"] = np.nan
-
-    star = get_star(agasc_id, use_supplement=False)
-
-    result.update(
-        {
-            "last_obs_time": last_obs_time,
-            "mag_aca": star["MAG_ACA"],
-            "mag_aca_err": star["MAG_ACA_ERR"] / 100,
-            "color": star["COLOR1"],
-            "n_obsids_fail": len(failures),
-            "n_obsids_suspect": np.count_nonzero(stats["obs_suspect"]),
-            "n_obsids": n_obsids,
-        }
-    )
-
-    if not np.any(~excluded_obs):
+    # Check requirements for calculating metrics.
+    if np.all(stats["excluded"]):  # this is a new field
         # this happens when all observations have been flagged as not OK a priory (obs-status).
         logger.debug(
             f"  Skipping star in get_agasc_id_stats({agasc_id=})."
@@ -1365,37 +1349,16 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
         )
         return result, stats, failures
 
-    # add failed observations to the list of excluded observations
-    excluded_obs += np.array([t is None for t in all_telem])
-    # and remove all excluded observations from all_telem
-    all_telem = [t for i, t in enumerate(all_telem) if not excluded_obs[i]]
-
-    if len(all_telem) == 0:
-        # and we reach here if some observations were not flagged as bad, but all failed.
+    if np.count_nonzero(stats["excluded"] | stats["no_telem"]) == len(stats):
+        # and we reach here if some observations were not flagged as bad, but
+        # there was some error getting telemetry.
         logger.debug(f"  get_agasc_id_stats({agasc_id=}): There is no OK observation.")
         return result, stats, failures
 
-    logger.debug("  identifying outlying observations...")
-    for s, t in zip(stats[~excluded_obs], all_telem, strict=True):
-        t["obs_ok"] = np.ones_like(t["mag_est_ok"], dtype=bool) * s["obs_ok"]
-        logger.debug(
-            "  identifying outlying observations "
-            f"(OBSID={s['obsid']}, mp_starcat_time={s['mp_starcat_time']})"
-        )
-        t["obs_outlier"] = np.zeros_like(t["mag_est_ok"])
-        if np.any(t["mag_est_ok"]) and s["f_mag_est_ok"] > 0 and s["obs_ok"]:
-            iqr = s["q75"] - s["q25"]
-            t["obs_outlier"] = (
-                t["mag_est_ok"]
-                & (iqr > 0)
-                & (
-                    (t["mags"] < s["q25"] - 1.5 * iqr)
-                    | (t["mags"] > s["q75"] + 1.5 * iqr)
-                )
-            )
-    all_telem = vstack([Table(t) for t in all_telem])
-    n_total = len(all_telem)
+    if np.count_nonzero(all_telem["mag_est_ok"] & all_telem["obs_ok"]) < 10:
+        return result, stats, failures
 
+    # First calculate metrics that do not depend on centroid filters
     kalman = (all_telem["AOACASEQ"] == "KALM") & (all_telem["AOPCADMD"] == "NPNT")
     all_telem = all_telem[kalman]  # non-npm/non-kalman are excluded
     n_kalman = len(all_telem)
@@ -1406,23 +1369,6 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
     sat_pix = (all_telem["AOACISP"] == "OK") & all_telem["obs_ok"]
     ion_rad = (all_telem["AOACIIR"] == "OK") & all_telem["obs_ok"]
 
-    f_mag_est_ok = np.count_nonzero(mag_est_ok) / len(mag_est_ok)
-
-    result.update(
-        {
-            "mag_obs_err": min_mag_obs_err,
-            "n_obsids_ok": np.count_nonzero(stats["obs_ok"]),
-            "n_no_mag": np.count_nonzero((~stats["obs_ok"]))
-            + np.count_nonzero(stats["f_mag_est_ok"][stats["obs_ok"]] < 0.3),
-            "n": n_total,
-            "n_mag_est_ok": np.count_nonzero(mag_est_ok),
-            "f_mag_est_ok": f_mag_est_ok,
-        }
-    )
-
-    if result["n_mag_est_ok"] < 10:
-        return result, stats, failures
-
     sigma_minus, q25, median, q75, sigma_plus = np.quantile(
         mags[mag_est_ok], [0.158, 0.25, 0.5, 0.75, 0.842]
     )
@@ -1431,37 +1377,16 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
     outlier_2 = mag_est_ok & ((mags > q75 + 3 * iqr) | (mags < q25 - 3 * iqr))
     outlier = all_telem["obs_outlier"]
 
-    # combine measurements using a weighted mean
-    obs_ok = stats["obs_ok"]
-    min_std = max(0.1, stats[obs_ok]["std"].min())
-    stats["w"][obs_ok] = np.where(
-        stats["std"][obs_ok] != 0, 1.0 / stats["std"][obs_ok], 1.0 / min_std
-    )
-    stats["mean_corrected"][obs_ok] = (
-        stats["t_mean"][obs_ok] + stats["mag_correction"][obs_ok]
-    )
-    stats["weighted_mean"][obs_ok] = (
-        stats["mean_corrected"][obs_ok] * stats["w"][obs_ok]
-    )
-
-    mag_weighted_mean = stats[obs_ok]["weighted_mean"].sum() / stats[obs_ok]["w"].sum()
-    mag_weighted_std = np.sqrt(
-        ((stats[obs_ok]["mean"] - mag_weighted_mean) ** 2 * stats[obs_ok]["w"]).sum()
-        / stats[obs_ok]["w"].sum()
-    )
-
     result.update(
         {
             "agasc_id": agasc_id,
             "n_mag_est_ok": np.count_nonzero(mag_est_ok),
-            "f_mag_est_ok": f_mag_est_ok,
+            "f_mag_est_ok": np.count_nonzero(mag_est_ok) / len(mag_est_ok),
             "median": median,
             "sigma_minus": sigma_minus,
             "sigma_plus": sigma_plus,
             "mean": np.mean(mags[mag_est_ok]),
             "std": np.std(mags[mag_est_ok]),
-            "mag_weighted_mean": mag_weighted_mean,
-            "mag_weighted_std": mag_weighted_std,
             "t_mean": np.mean(mags[mag_est_ok & (~outlier)]),
             "t_std": np.std(mags[mag_est_ok & (~outlier)]),
             "n_outlier": np.count_nonzero(mag_est_ok & outlier),
@@ -1474,8 +1399,9 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
         }
     )
 
+    # Calculate metrics that depend on centroid filters
     residual_ok = {
-        3: all_telem["dr"] < 3,
+        3: (np.sqrt(all_telem["dy"] ** 2 + all_telem["dz"] ** 2) < 3),
         5: (np.abs(all_telem["dy"]) < 5) & (np.abs(all_telem["dz"]) < 5),
     }
     dr_tag = {3: "dr3", 5: "dbox5"}
@@ -1521,6 +1447,7 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
             }
         )
 
+    # main results, which correspond to the "dbox5" residual cut
     result.update(
         {
             "mag_obs": result["t_mean_dbox5"],
@@ -1547,3 +1474,179 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
 
     logger.debug(f"  stats for AGASC ID {agasc_id}:  {stats['mag_obs'][0]}")
     return result, stats, failures
+
+
+def get_weighted_mean(stats):
+    # combine measurements using a weighted mean
+    weights = np.nan * np.ones(len(stats))
+    mean_corrected = np.nan * np.ones(len(stats))
+    weighted_mean = np.nan * np.ones(len(stats))
+    mag_weighted_mean = 0.0
+    mag_weighted_std = 0.0
+
+    obs_ok = stats["obs_ok"]
+    if np.any(obs_ok):
+        min_std = max(0.1, stats[obs_ok]["std"].min())
+        weights[obs_ok] = np.where(
+            stats["std"][obs_ok] != 0, 1.0 / stats["std"][obs_ok], 1.0 / min_std
+        )
+        mean_corrected[obs_ok] = (
+            stats["t_mean"][obs_ok] + stats["mag_correction"][obs_ok]
+        )
+        weighted_mean[obs_ok] = mean_corrected[obs_ok] * weights[obs_ok]
+
+        mag_weighted_mean = weighted_mean[obs_ok].sum() / weights[obs_ok].sum()
+        mag_weighted_std = np.sqrt(
+            ((stats[obs_ok]["mean"] - mag_weighted_mean) ** 2 * weights[obs_ok]).sum()
+            / weights[obs_ok].sum()
+        )
+
+    result = {
+        "weights": weights,
+        "mean_corrected": mean_corrected,
+        "weighted_mean": weighted_mean,
+        "mag_weighted_mean": mag_weighted_mean,
+        "mag_weighted_std": mag_weighted_std,
+    }
+    return result
+
+
+def get_multi_obs_stats(star_obs, telem=None, obs_status_override=None):
+    """
+    Get summary magnitude statistics for an AGASC ID.
+
+    This function deals with several errors that can occur, and assigns various success/error flags
+    to each observation:
+
+        - obs_ok: OK observations are considered OK based on criteria listed below, or are
+          have `status == 0` in `obs_status_override`.
+        - obs_suspect: observations are considered suspect if they have `status > 1` in
+          `obs_status_override`, and do not fulfill the criteria for being OK.
+        - obs_fail: observations where there was an exception getting the telemetry or calculating
+          the stats.
+        - no_telem: observations where there was an exception getting the telemetry.
+
+    Criteria for an OK observation:
+
+        - n > 10, where n is the total number of telemetry entries in the observation.
+        - f_mag_est_ok > 0.3, where f_mag_est_ok is the fraction of telemetry entries with
+          (AOACASEQ==KALM & AOACIIR==OK & AOPCADMD==NPNT & AOACFCT==TRAK).
+        - lf_variability_100s < 1, where lf_variability_100s is the largest change in the magnitude
+          smoothed using a 100s rolling window.
+
+    :param star_obs: Table
+        Table of star observations.
+    :param telem: list
+        List of telemetry tables for each observation. Must be in the same order as star_obs.
+        This should generally be the result of get_telemetry_by_observations.
+    :param obs_status_override: dict.
+        Dictionary overriding the OK flag for specific observations.
+        Keys are (OBSID, AGASC ID) pairs, values are dictionaries like
+        {'obs_ok': True, 'comments': 'some comment'}
+    :return: dict
+        dictionary with stats
+    """
+    if not obs_status_override:
+        obs_status_override = {}
+
+    if telem is None:
+        telem = get_telemetry_by_observations(
+            star_obs, ignore_exceptions=True, as_table=False
+        )
+
+    if len(telem) != len(star_obs):
+        raise ValueError(
+            f"Length of telem ({len(telem)}) does not match length of star_obs ({len(star_obs)})."
+        )
+
+    # exclude star_obs that are in obs_status_override with status != 0
+    excluded_obs = np.array(
+        [
+            (
+                (oi, ai) in obs_status_override
+                and obs_status_override[(oi, ai)]["status"] != 0
+            )
+            for oi, ai in star_obs[["mp_starcat_time", "agasc_id"]]
+        ]
+    )
+    if np.any(excluded_obs):
+        logger.debug(
+            "  Excluding observations flagged in obs-status table: "
+            f"{list(star_obs[excluded_obs]['obsid'])}"
+        )
+
+    included_obs = np.array(
+        [
+            (
+                (oi, ai) in obs_status_override
+                and obs_status_override[(oi, ai)]["status"] == 0
+            )
+            for oi, ai in star_obs[["mp_starcat_time", "agasc_id"]]
+        ]
+    )
+    if np.any(included_obs):
+        logger.debug(
+            "  Including observations marked OK in obs-status table: "
+            f"{list(star_obs[included_obs]['obsid'])}"
+        )
+
+    failures = []
+    stats = []
+    for i, obs in enumerate(star_obs):
+        oi, ai = obs["mp_starcat_time", "agasc_id"]
+        comment = ""
+        if (oi, ai) in obs_status_override:
+            status = obs_status_override[(oi, ai)]
+            logger.debug(
+                f"  overriding status for (AGASC ID {ai}, starcat time {oi}): "
+                f"{status['status']}, {status['comments']}"
+            )
+            comment = status["comments"]
+
+        obs_telem = telem[i]
+        if "error_code" in obs_telem:
+            fail = obs_telem["error_code"] > 2
+            obs_stat = get_obs_stats(obs, telem=[])
+            obs_stat.update(
+                {
+                    "obs_suspect": False,
+                    "obs_fail": fail,
+                    "excluded": excluded_obs[i],
+                    "no_telem": True,
+                    "comments": comment
+                    if excluded_obs[i]
+                    else f"Error: {obs_telem['msg']}.",
+                }
+            )
+            stats.append(obs_stat)
+            if fail:
+                failures.append(obs_telem)
+        else:
+            obs_stat = get_obs_stats(
+                obs, telem={k: obs_telem[k] for k in obs_telem.colnames}
+            )
+            obs_ok = included_obs[i] | (~excluded_obs[i] & obs_stat["obs_ok"])
+            obs_stat.update(
+                {
+                    "obs_ok": obs_ok,
+                    "obs_suspect": not obs_ok and not excluded_obs[i],
+                    "obs_fail": False,
+                    "excluded": excluded_obs[i],
+                    "no_telem": False,
+                    "comments": comment,
+                }
+            )
+            stats.append(obs_stat)
+            if obs_stat["obs_suspect"]:
+                failures.append(
+                    dict(
+                        MagStatsException(
+                            msg="Suspect observation",
+                            agasc_id=obs["agasc_id"],
+                            obsid=obs["obsid"],
+                            mp_starcat_time=obs["mp_starcat_time"],
+                        )
+                    )
+                )
+
+    return Table(stats), failures

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -1303,18 +1303,18 @@ def get_agasc_id_stats(
     result = {
         "last_obs_time": 0,
         "agasc_id": agasc_id,
-        "mag_aca": np.nan,
-        "mag_aca_err": np.nan,
+        "mag_aca": star["MAG_ACA"],
+        "mag_aca_err": star["MAG_ACA_ERR"] / 100,
         "mag_obs": 0.0,
-        "mag_obs_err": np.nan,
+        "mag_obs_err": min_mag_obs_err,
         "mag_obs_std": 0.0,
-        "color": np.nan,
-        "n_obsids": 0,
-        "n_obsids_fail": 0,
+        "color": star["COLOR1"],
+        "n_obsids": n_obsids,
+        "n_obsids_fail": len(failures),
         "n_obsids_suspect": 0,
         "n_obsids_ok": 0,
         "n_no_mag": 0,
-        "n": 0,
+        "n": len(all_telem),
         "n_ok": 0,
         "n_ok_3": 0,
         "n_ok_5": 0,
@@ -1350,24 +1350,21 @@ def get_agasc_id_stats(
         "f_ok_5": 0.0,
     }
 
-    # this can be moved up
+    if len(stats) == 0:
+        logger.debug(f"  No stats for AGASC ID {agasc_id}.")
+        return result, stats, failures
+
     result.update(
         {
-            "color": star["COLOR1"],
             "last_obs_time": CxoTime(stats["mp_starcat_time"][-1]).cxcsec,
-            "mag_aca": star["MAG_ACA"],
-            "mag_aca_err": star["MAG_ACA_ERR"] / 100,
-            "mag_obs_err": min_mag_obs_err,
-            "n_obsids_fail": len(failures),
-            "n": len(all_telem),
             "n_obsids_suspect": np.count_nonzero(stats["obs_suspect"]),
-            "n_obsids": n_obsids,
             "n_obsids_ok": np.count_nonzero(stats["obs_ok"]),
-            "n_no_mag": np.count_nonzero((~stats["obs_ok"]))
-            + np.count_nonzero(stats["f_mag_est_ok"][stats["obs_ok"]] < 0.3),
+            "n_no_mag": (
+                np.count_nonzero((~stats["obs_ok"]))
+                + np.count_nonzero(stats["f_mag_est_ok"][stats["obs_ok"]] < 0.3)
+            ),
         }
     )
-
     for tag in ["dr3", "dbox5"]:
         result.update(
             {

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -879,6 +879,8 @@ def get_obs_stats(obs, telem=None):
             "lf_variability_1000s": np.inf,
             "tempccd": np.nan,
             "dr_star": np.inf,
+            "no_telem": True,
+            "excluded": False,
         }
     )
 
@@ -973,6 +975,7 @@ def calc_obs_stats(telem):
         "n_mag_est_ok_3": n_mag_est_ok_3,
         "n_mag_est_ok_5": n_mag_est_ok_5,
         "dr_star": dr_star,
+        "no_telem": False,
     }
     if stats["n_mag_est_ok_3"] < 10:
         return stats

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -546,7 +546,9 @@ def get_telemetry_by_observations(observations, ignore_exceptions=False, as_tabl
                 logger.debug(f"{exc.exception['type']} {exc.exception['value']}")
                 for step in exc.exception["traceback"]:
                     logger.debug(step)
-                telem.append(dict(exc))
+                exc_dict = dict(exc)
+                exc_dict["msg"] = f"{exc.exception['type']} - {exc.exception['value']}"
+                telem.append(exc_dict)
             else:
                 logger.info(f"{agasc_id=}, obsid={obs['obsid']} failed")
                 logger.info(f"{exc.exception['type']} {exc.exception['value']}")

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -550,7 +550,13 @@ def get_telemetry_by_observations(observations, ignore_exceptions=False, as_tabl
                 raise
 
     if telem:
-        return vstack([Table(tel) for tel in telem]) if as_table else telem
+        # we ignore entries with error_code here because this means ignore_exceptions is true
+        # (otherwise the exception would have been raised already)
+        return (
+            vstack([Table(tel) for tel in telem if "error_code" not in tel])
+            if as_table
+            else telem
+        )
 
     return []
 
@@ -584,7 +590,8 @@ def add_obs_info(telem, obs_stats):
         o = telem["obsid"] == obsid
         telem["obs_ok"][o] = np.ones(np.count_nonzero(o), dtype=bool) * s["obs_ok"]
         if (
-            np.any(telem["mag_est_ok"][o])
+            len(telem[o]) > 0
+            and np.any(telem["mag_est_ok"][o])
             and s["f_mag_est_ok"] > 0
             and np.isfinite(s["q75"])
             and np.isfinite(s["q25"])

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -17,6 +17,7 @@ from Chandra.Time import DateTime
 from chandra_aca.transform import count_rate_to_mag, pixels_to_yagzag
 from cheta import fetch
 from cxotime import CxoTime
+from cxotime import units as u
 from kadi import events
 from mica.archive import aca_l0
 from mica.archive.aca_dark.dark_cal import get_dark_cal_image
@@ -1178,7 +1179,9 @@ AGASC_ID_STATS_INFO = {
 }
 
 
-def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
+def get_agasc_id_stats(
+    agasc_id, obs_status_override=None, tstop=None, no_telem_time=14 * u.day
+):
     """
     Get summary magnitude statistics for an AGASC ID.
 
@@ -1189,6 +1192,8 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
         {'obs_ok': True, 'comments': 'some comment'}
     :param tstop: cxotime-compatible timestamp
         Only entries in catalogs.STARS_OBS prior to this timestamp are considered.
+    :param no_telem_time: astropy Quantity
+        Time interval to consider for discarding recent observations with no telemetry.
     :return: dict
         dictionary with stats
     """
@@ -1204,11 +1209,28 @@ def get_agasc_id_stats(agasc_id, obs_status_override=None, tstop=None):
     ]
     star_obs.sort("mp_starcat_time")
 
-    n_obsids = len(star_obs)
-
     all_telem = get_telemetry_by_observations(
         star_obs, ignore_exceptions=True, as_table=False
     )
+
+    # discard observations with no telemetry if they occured in the last two weeks.
+    discard = np.array(
+        [
+            ("error_code" in tlm)
+            and (tlm["mp_starcat_time"] > CxoTime() - no_telem_time)
+            for tlm in all_telem
+        ]
+    )
+    if np.any(discard):
+        obsids = [str(obsid) for obsid in star_obs["obsid"][discard]]
+        logger.debug(
+            f"Discarding recent observations with no telemetry (OBSIDs {' '.join(obsids)}."
+        )
+        star_obs = star_obs[~discard]
+        all_telem = [tlm for sel, tlm in zip(~discard, all_telem, strict=True) if sel]
+
+    n_obsids = len(star_obs)
+
     stats, failures = get_multi_obs_stats(
         star_obs, obs_status_override=obs_status_override, telem=all_telem
     )

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -1622,6 +1622,8 @@ def get_multi_obs_stats(star_obs, telem=None, obs_status_override=None):
             if fail:
                 failures.append(obs_telem)
         else:
+            # this conversion to Table might be needed to make sure different inputs work
+            obs_telem = Table(obs_telem)
             obs_stat = get_obs_stats(
                 obs, telem={k: obs_telem[k] for k in obs_telem.colnames}
             )

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -1238,16 +1238,21 @@ def get_agasc_id_stats(
         star_obs, obs_status_override=obs_status_override, telem=all_telem
     )
 
-    # combine magnitude estimates using a weighted mean
-    weighted_mean = get_weighted_mean(stats)
-    stats["w"] = weighted_mean["weights"]
-    stats["mean_corrected"] = weighted_mean["mean_corrected"]
-    stats["weighted_mean"] = weighted_mean["weighted_mean"]
+    # we do this in this method because a weighted mean doesn't make much sense for a list
+    # of observations. It only makes sense when considering all observations of a star.
+    if len(stats) > 0:
+        # combine magnitude estimates using a weighted mean
+        weighted_mean = get_weighted_mean(stats)
+        stats["w"] = weighted_mean["weights"]
+        stats["mean_corrected"] = weighted_mean["mean_corrected"]
+        stats["weighted_mean"] = weighted_mean["weighted_mean"]
+    else:
+        # or make sure column exists
+        stats["w"] = np.array([])
+        stats["mean_corrected"] = np.array([])
+        stats["weighted_mean"] = np.array([])
 
     star = get_star(agasc_id, use_supplement=False)
-
-    # still need to check that this is the same as before
-    last_obs_time = CxoTime(stats["mp_starcat_time"][-1]).cxcsec
 
     logger.debug("  identifying outlying observations...")
     for s, t in zip(stats, all_telem, strict=True):
@@ -1333,7 +1338,7 @@ def get_agasc_id_stats(
     result.update(
         {
             "color": star["COLOR1"],
-            "last_obs_time": last_obs_time,
+            "last_obs_time": CxoTime(stats["mp_starcat_time"][-1]).cxcsec,
             "mag_aca": star["MAG_ACA"],
             "mag_aca_err": star["MAG_ACA_ERR"] / 100,
             "mag_obs_err": min_mag_obs_err,

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -1673,11 +1673,7 @@ def get_multi_obs_stats(star_obs, telem=None, obs_status_override=None):
             if fail:
                 failures.append(obs_telem)
         else:
-            # this conversion to Table might be needed to make sure different inputs work
-            obs_telem = Table(obs_telem)
-            obs_stat = get_obs_stats(
-                obs, telem={k: obs_telem[k] for k in obs_telem.colnames}
-            )
+            obs_stat = get_obs_stats(obs, telem=obs_telem)
             obs_ok = included_obs[i] | (~excluded_obs[i] & obs_stat["obs_ok"])
             obs_stat.update(
                 {

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -541,6 +541,11 @@ def get_telemetry_by_observations(observations, ignore_exceptions=False, as_tabl
                 mp_starcat_time=obs["mp_starcat_time"],
             )
             if ignore_exceptions:
+                logger.debug("Ignored unknown exception:")
+                logger.debug(f"{agasc_id=}, obsid={obs['obsid']} failed")
+                logger.debug(f"{exc.exception['name']} {exc.exception['value']}")
+                for step in exc.exception["traceback"]:
+                    logger.debug(step)
                 telem.append(dict(exc))
             else:
                 logger.info(f"{agasc_id=}, obsid={obs['obsid']} failed")

--- a/agasc/supplement/magnitudes/mag_estimate.py
+++ b/agasc/supplement/magnitudes/mag_estimate.py
@@ -530,7 +530,7 @@ def get_telemetry_by_observations(observations, ignore_exceptions=False, as_tabl
                 telem.append(dict(exc))
             else:
                 logger.info(f"{agasc_id=}, obsid={obs['obsid']} failed")
-                logger.info(f"{exc.exception['name']} {exc.exception['value']}")
+                logger.info(f"{exc.exception['type']} {exc.exception['value']}")
                 for step in exc.exception["traceback"]:
                     logger.info(step)
         except Exception:
@@ -543,13 +543,13 @@ def get_telemetry_by_observations(observations, ignore_exceptions=False, as_tabl
             if ignore_exceptions:
                 logger.debug("Ignored unknown exception:")
                 logger.debug(f"{agasc_id=}, obsid={obs['obsid']} failed")
-                logger.debug(f"{exc.exception['name']} {exc.exception['value']}")
+                logger.debug(f"{exc.exception['type']} {exc.exception['value']}")
                 for step in exc.exception["traceback"]:
                     logger.debug(step)
                 telem.append(dict(exc))
             else:
                 logger.info(f"{agasc_id=}, obsid={obs['obsid']} failed")
-                logger.info(f"{exc.exception['name']} {exc.exception['value']}")
+                logger.info(f"{exc.exception['type']} {exc.exception['value']}")
                 for step in exc.exception["traceback"]:
                     logger.info(step)
                 raise

--- a/agasc/supplement/magnitudes/templates/run_report.html
+++ b/agasc/supplement/magnitudes/templates/run_report.html
@@ -56,6 +56,7 @@
     {%- for section in sections %}
     <a name="{{ section.id }}"> </a>
     <h3> {{ section.title }} </h3>
+    <p> {{ section.description }} </p>
     <table class="table table-hover">
       <tr>
       <tr>

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -76,7 +76,7 @@ def get_agasc_id_stats(
             agasc_stat, obs_stat, obs_fail = mag_estimate.get_agasc_id_stats(
                 agasc_id=agasc_id, obs_status_override=obs_status_override, tstop=tstop
             )
-            if agasc_stats["n_obsids_ok"] == 0:
+            if agasc_stat["n_obsids_ok"] == 0:
                 logger.debug(f"Skipping {agasc_id} because it has no OK observations")
                 continue
             agasc_stats.append(agasc_stat)

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -581,6 +581,9 @@ def do(
     processing_cutoff = stop
     for obs, tel in zip(recent_obs, telem, strict=True):
         if "error_code" in tel:
+            logger.info(
+                f"Skipping OBSID {obs['obsid']} at  {obs['mp_starcat_time']} ({obs['msg']})"
+            )
             continue
         logger.info(
             f"Latest observation with telemetry: OBSID {obs['obsid']} at  {obs['mp_starcat_time']}"

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -234,6 +234,11 @@ def update_mag_stats(obs_stats, agasc_stats, fails, outdir="."):
     if obs_stats is not None and len(obs_stats):
         filename = outdir / "mag_stats_obsid.fits"
         logger.debug(f"Updating {filename}")
+
+        # these two were added late, and are not necessary in the file, so the file was not updated
+        columns = list(set(obs_stats.colnames) - {"excluded", "no_telem"})
+        obs_stats = obs_stats[columns]
+
         if filename.exists():
             obs_stats = _update_table(
                 table.Table.read(filename), obs_stats, keys=["agasc_id", "obsid"]

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -729,10 +729,16 @@ def do(
                 updated_stars["mag_aca_err"] != 0
             )
             sections = [
-                {"id": "new_stars", "title": "New Stars", "stars": new_stars},
+                {
+                    "id": "new_stars",
+                    "title": "New Stars",
+                    "description": "These are stars that are being added to the supplement.",
+                    "stars": new_stars,
+                },
                 {
                     "id": "updated_stars",
                     "title": "Updated Stars",
+                    "description": "These are stars that are being updated in the supplement.",
                     "stars": (
                         updated_stars["agasc_id"][updt_mag].tolist()
                         if len(updated_stars[updt_mag])
@@ -742,6 +748,9 @@ def do(
                 {
                     "id": "not_updated_stars",
                     "title": "Magnitude not Updated",
+                    "description": (
+                        "These are stars whose magnitudes are not being updated in the supplement."
+                    ),
                     "stars": (
                         updated_stars["agasc_id"][~updt_mag].tolist()
                         if len(updated_stars[~updt_mag])
@@ -750,7 +759,14 @@ def do(
                 },
                 {
                     "id": "other_stars",
-                    "title": "Other (unexpectedly not updated)",
+                    "title": "Stars in Limbo",
+                    "description": (
+                        "These are stars that were in the list to process but are neither being"
+                        " added or updated. This can happen if all observations for that star"
+                        " fail or are skipped for some reason (e.g. a star with a single recent"
+                        " observation that is suspect). This is resolved after the observations"
+                        " are dispositioned or the failures are fixed."
+                    ),
                     "stars": list(
                         agasc_stats["agasc_id"][
                             ~np.isin(agasc_stats["agasc_id"], new_stars)

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -79,10 +79,6 @@ def get_agasc_id_stats(
             agasc_stats.append(agasc_stat)
             obs_stats.append(obs_stat)
             fails += obs_fail
-        except mag_estimate.MagStatsException as e:
-            msg = str(e)
-            logger.debug(msg)
-            fails.append(dict(e))
         except Exception as e:
             # transform Exception to MagStatsException for standard book keeping
             msg = f"Unexpected Error: {e}"

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -582,7 +582,8 @@ def do(
     for obs, tel in zip(recent_obs, telem, strict=True):
         if "error_code" in tel:
             logger.info(
-                f"Skipping OBSID {obs['obsid']} at  {obs['mp_starcat_time']} ({obs['msg']})"
+                f"Skipping OBSID {obs['obsid']} at  {obs['mp_starcat_time']}"
+                f" ({tel.get('msg', tel['error_code'])})"
             )
             continue
         logger.info(

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -569,7 +569,9 @@ def do(
     # find the latest observation with telemetry: take one star-obs per observation,
     # and get telemetry for each just to find the last observation with data.
     # Cut processing off right after that time.
-    recent_obs = stars_obs[stars_obs["mp_starcat_time"] > stop - 7 * u.day].copy()
+    recent_obs = stars_obs[
+        stars_obs["mp_starcat_time"] > CxoTime(stop) - 7 * u.day
+    ].copy()
     recent_obs = recent_obs.group_by("mp_starcat_time")
     recent_obs = recent_obs[recent_obs.groups.indices[:-1]]
     recent_obs.sort(["mp_starcat_time"], reverse=True)

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -260,8 +260,21 @@ def update_supplement(agasc_stats, filename, include_all=True, d_mag_threshold=0
     """
     Update the magnitude table of the AGASC supplement.
 
-    :param agasc_stats:
-    :param filename:
+    This function returns two list of stars: new stars and updated stars, which are stars that are
+    not in the supplement already, and stars thar are in the supplement before this update. Note
+    that "updated" stars are not necessarily updated in the supplement. If a star has a small change
+    in magnitude or magnitude uncertainty (less than d_mag_threshold), its magnitude is not updated
+    in the supplement, but it is still included in the "updated" stars list.
+
+    This function compares the last_obs_time of the stars in the supplement and in agasc_stats.
+    If last_obs_time is the same, then the star is not updated in the supplement (and not included
+    in the "updated" stars list), even if there is a change in magnitude. This can happen if all
+    observations since last_updated are excluded or failed.
+
+    :param agasc_stats: astropy.table.Table
+        The table with the new stats for each AGASC ID. It must include the columns in MAGS_DTYPE.
+    :param filename: str or pathlib.Path
+        The filename of the supplement to update.
     :param include_all: bool
         if True, all OK entries are included in supplement.
         if False, only OK entries marked 'selected_*'
@@ -269,6 +282,8 @@ def update_supplement(agasc_stats, filename, include_all=True, d_mag_threshold=0
         If the absolute difference between the new and the current mag_aca is less than this value,
         mag_aca is not updated. Note that last_obs_time is always updated.
     :return:
+        new_stars: list of AGASC IDs that are new in the supplement.
+        updated_stars: list of AGASC IDs that are already in the supplement.
     """
     if agasc_stats is None or len(agasc_stats) == 0:
         return [], []
@@ -681,6 +696,10 @@ def do(
     except Exception as e:
         logger.warning(f"Failed to write {obs_status_file}: {e}")
 
+    # the following "updated_stars" is not the actual table of stars that were updated in the
+    # supplement, but the table of stars that would be updated if there were no threshold on d_mag.
+    # In other words: stars with tiny magnitude updates are not updated in the supplement, but they
+    # are included in "updated_stars".
     new_stars, updated_stars = update_supplement(agasc_stats, filename=filename)
     logger.info(f"  {len(new_stars)} new stars, {len(updated_stars)} updated stars")
 
@@ -766,11 +785,13 @@ def do(
                     "id": "other_stars",
                     "title": "Stars in Limbo",
                     "description": (
-                        "These are stars that were in the list to process but are neither being"
-                        " added or updated. This can happen if all observations for that star"
-                        " fail or are skipped for some reason (e.g. a star with a single recent"
-                        " observation that is suspect). This is resolved after the observations"
-                        " are dispositioned or the failures are fixed."
+                        "This section is here for informational purposes."
+                        " These are stars that were in the list to process but are neither being"
+                        " added nor updated. This can happen if all recent observations for that"
+                        " star fail or are skipped for some reason (e.g. all recent observation are"
+                        " so recent that telemetry is not available). This is resolved after the"
+                        " observations are dispositioned or the failures are fixed."
+                        " If there are errors, they should show up elsewhere in this report."
                     ),
                     "stars": list(
                         agasc_stats["agasc_id"][

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -76,6 +76,9 @@ def get_agasc_id_stats(
             agasc_stat, obs_stat, obs_fail = mag_estimate.get_agasc_id_stats(
                 agasc_id=agasc_id, obs_status_override=obs_status_override, tstop=tstop
             )
+            if agasc_stats["n_obsids_ok"] == 0:
+                logger.debug(f"Skipping {agasc_id} because it has no OK observations")
+                continue
             agasc_stats.append(agasc_stat)
             obs_stats.append(obs_stat)
             fails += obs_fail

--- a/agasc/supplement/magnitudes/update_mag_supplement.py
+++ b/agasc/supplement/magnitudes/update_mag_supplement.py
@@ -566,6 +566,29 @@ def do(
         np.isin(star_obs_catalogs.STARS_OBS["agasc_id"], agasc_ids)
     ]
 
+    # find the latest observation with telemetry: take one star-obs per observation,
+    # and get telemetry for each just to find the last observation with data.
+    # Cut processing off right after that time.
+    recent_obs = stars_obs[stars_obs["mp_starcat_time"] > stop - 7 * u.day].copy()
+    recent_obs = recent_obs.group_by("mp_starcat_time")
+    recent_obs = recent_obs[recent_obs.groups.indices[:-1]]
+    recent_obs.sort(["mp_starcat_time"], reverse=True)
+    telem = mag_estimate.get_telemetry_by_observations(
+        recent_obs, ignore_exceptions=True, as_table=False
+    )
+    processing_cutoff = stop
+    for obs, tel in zip(recent_obs, telem, strict=True):
+        if "error_code" in tel:
+            continue
+        logger.info(
+            f"Latest observation with telemetry: OBSID {obs['obsid']} at  {obs['mp_starcat_time']}"
+        )
+        processing_cutoff = CxoTime(obs["mp_starcat_time"]) + 1 * u.second
+        break
+    # and some AGASC Ids might be dropped because they are only observed in observations after the
+    # processing cutoff
+    agasc_ids = np.unique(agasc_ids)
+
     # if supplement exists:
     # - drop bad stars
     # - get OBS status override
@@ -662,7 +685,7 @@ def do(
 
     obs_stats, agasc_stats, fails = get_stats(
         agasc_ids,
-        tstop=stop,
+        tstop=processing_cutoff,
         obs_status_override=obs_status_override,
         no_progress=no_progress,
     )


### PR DESCRIPTION
## Description

This PR refactors the way obs-stats are calculated to disentangle it from the agasc_stats (the supplement is based on stars, so the processing did not allow direct processing of observations independently).

After that, I fixed a few issues:
- _Recent_ observations without telemetry are discarded before trying to process them. With this change, recent observations without telemetry should not show up in any warning in any report. Older observations without telemetry are still shown in yellow (as can be seen in functional testing)
- Added descriptions for the sections in the supplement report.

This PR fixes a few other issues:
- When there is an unexpected error, now the error message is reported instead of showing "Unknown error". This can be seen in the functional test: some stars have `PermissionError`
- By dropping the newer observations without telemetry, the last_observed date is before the dropped observation, and this protects against the case where there is data for a later observation, which would set last_observed to a later date, causing the observation to be skipped on subsequent runs.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux


```
jgonzale agasc $ git rev-parse HEAD
daf4a4a32fbe99b19e5abfa3f19bf0f9ca8caece
jgonzale agasc $ pytest agasc
========================================================= test session starts =========================================================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 79 items                                                                                                                    

agasc/tests/test_agasc_1.py .......                                                                                             [  8%]
agasc/tests/test_agasc_2.py ...............................................                                                     [ 68%]
agasc/tests/test_agasc_healpix.py ...........                                                                                   [ 82%]
agasc/tests/test_obs_status.py ..............                                                                                   [100%]

=================================================== 79 passed in 105.09s (0:01:45) ====================================================

```

Independent check of unit tests by Jean
- [x] Linux
```
jeanconn-kady> pytest
============================================ test session starts =============================================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 79 items                                                                                           

agasc/tests/test_agasc_1.py .......                                                                    [  8%]
agasc/tests/test_agasc_2.py ...............................................                            [ 68%]
agasc/tests/test_agasc_healpix.py ...........                                                          [ 82%]
agasc/tests/test_obs_status.py ..............                                                          [100%]

======================================= 79 passed in 116.16s (0:01:56) =======================================
jeanconn-kady> git rev-parse HEAD
daf4a4a32fbe99b19e5abfa3f19bf0f9ca8caece
```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Running weekly update in test environment on `2026:187`. Output:
- [flight](https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement_reports/weekly/2026:187)
- [branch](https://icxc.cfa.harvard.edu/aspect/test_review_outputs/agasc/pr-208/supplement_reports/weekly/2026:187)

The differences summarized:
- There are two stars in flight and not in the branch (31069328 and 897587816) because they are right at the edge of the time range. These two stars are scheduled in OBSID 30267 and 31346. The last observations in flight are [32412, 31404, 31346, 30267] whereas the branch stopped at 32412. For these stars, there are no observations within the time range considered after you remove these three OBSIDs. Other stars in these three OBSIDs do have observations in the time range.
- 23 stars are in flight and not in the branch because all their observations have "no telemetry" errors, so the branch treats them as if they do not exist yet.
- 50 stars have observations with "no telemetry" errors in flight which got dropped in the branch. For all these, we checked that the last observation date is earlier than the dropped observation (no instances where there is a later observation). Of these:
  - 13 show as "magnitude not updated" (there are _other_ new observations for processing, there are mag updates, but the mag changes are small -> no update)
  - 37 show as "in limbo". These are the ones where there are no new observations up for processing (they are processed already) so nothing was done even though they were in the list. Note the "suspect" observation also in limbo (that just means there was no mag update even though it was in the list.
- AGASC ID 31983336 had file permission issues
