### PR TITLE
Always use call_args.yml to store arguments in supplement report

### DIFF
--- a/agasc/scripts/update_mag_supplement.py
+++ b/agasc/scripts/update_mag_supplement.py
@@ -256,7 +256,7 @@ def main():
         and (args["reports_dir"] / f"{args['report_date'].date[:8]}").exists()
     ):
         args_log_file.replace(
-            args["reports_dir"] / f"{args['report_date'].date[:8]}" / args_log_file.name
+            args["reports_dir"] / f"{args['report_date'].date[:8]}" / "call_args.yml"
         )
 
 


### PR DESCRIPTION
## Description

The agasc supplement update always runs in the same directory, and it always generates a file with the command-line arguments. This file is called call-args.yml by default, but if the file already exists it is called `call_args.<N>.yml`. It checks which is the last call-args file and sets N to not overwrite an existing file. At the end of the run, the file is **moved** to the reports directory.

The issue in #209:
- When making dispositions, the script expects a file called call-args.yml in the reports directory
- if there were already args files in the working directory, the file is not called call_args.yml but `call_args.<N>.yml`
- the script fails.

The fix: always rename the file that is placed in the reports directory so it is the expected name.

It is not clear why there were call-args files in the work directory to begin with, because they are supposed to be moved. Maybe this happened when I tried debugging something and left a file.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #209

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->

- [x] Mac

```
(ska3-flight) ~/SAO/git/agasc call-args-filename $ git rev-parse HEAD
1d6d2e03a1062397186ea80a1d9e278d9207fd1f
(ska3-flight) ~/SAO/git/agasc call-args-filename $ pytest agasc
===================================================================== test session starts =====================================================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/javierg/SAO/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 79 items                                                                                                                                            

agasc/tests/test_agasc_1.py .......                                                                                                                     [  8%]
agasc/tests/test_agasc_2.py ..........sssss..........ss....................                                                                             [ 68%]
agasc/tests/test_agasc_healpix.py .ssssssssss                                                                                                           [ 82%]
agasc/tests/test_obs_status.py ..............                                                                                                           [100%]

=============================================================== 62 passed, 17 skipped in 8.99s ================================================================

```

Independent check of unit tests by Jean
- [x] Linux
```
Switched to a new branch 'call-args-filename'
jeanconn-kady> pytest
============================================ test session starts ============================================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 79 items                                                                                          

agasc/tests/test_agasc_1.py .......                                                                   [  8%]
agasc/tests/test_agasc_2.py ...............................................                           [ 68%]
agasc/tests/test_agasc_healpix.py ...........                                                         [ 82%]
agasc/tests/test_obs_status.py ..............                                                         [100%]

====================================== 79 passed in 112.82s (0:01:52) =======================================
jeanconn-kady> git rev-parse HEAD
1d6d2e03a1062397186ea80a1d9e278d9207fd1f

```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
